### PR TITLE
Add offer grouping

### DIFF
--- a/db/db_suite_test.go
+++ b/db/db_suite_test.go
@@ -25,8 +25,7 @@ func TestDb(t *testing.T) {
 	RunSpecs(t, "Db Suite")
 }
 
-var _ = BeforeSuite(func(done Done) {
-	defer close(done)
+var _ = BeforeSuite(func() {
 	mocks = createMocks()
 	createClient()
 	wipeDb()
@@ -36,14 +35,12 @@ var _ = BeforeSuite(func(done Done) {
 // RebuildDBAfterEach can be used on tests or test blocks that mess up the data
 // in the DB. Most commonly inserts and updates
 var RebuildDBAfterEach = func() {
-	AfterEach(func(done Done) {
-		defer close(done)
+	AfterEach(func() {
 		wipeDb()
 		initCollections()
 	})
 }
-var _ = AfterSuite(func(done Done) {
-	defer close(done)
+var _ = AfterSuite(func() {
 	wipeDb()
 	dbClient.Disconnect()
 })

--- a/db/db_suite_test.go
+++ b/db/db_suite_test.go
@@ -101,7 +101,7 @@ func initUsersCollection() {
 
 func createTestDbConf() (dbConfig *db.Config) {
 	dbConfig = &db.Config{
-		DbURL:  "mongodb://localhost/test",
+		DbURL:  "127.0.0.1",
 		DbName: "test",
 	}
 	return

--- a/db/db_suite_test.go
+++ b/db/db_suite_test.go
@@ -10,13 +10,14 @@ import (
 )
 
 var (
-	dbClient              *db.Client
-	offersCollection      db.Offers
-	tagsCollection        db.Tags
-	regionsCollection     db.Regions
-	restaurantsCollection db.Restaurants
-	usersCollection       db.Users
-	mocks                 *Mocks
+	dbClient                  *db.Client
+	offersCollection          db.Offers
+	offerGroupPostsCollection db.OfferGroupPosts
+	tagsCollection            db.Tags
+	regionsCollection         db.Regions
+	restaurantsCollection     db.Restaurants
+	usersCollection           db.Users
+	mocks                     *Mocks
 )
 
 func TestDb(t *testing.T) {
@@ -58,6 +59,7 @@ func createClient() {
 
 func initCollections() {
 	initOffersCollection()
+	initOfferGroupPostsCollection()
 	initTagsCollection()
 	initRegionsCollection()
 	initRestaurantsCollection()
@@ -70,6 +72,10 @@ func initOffersCollection() {
 	Expect(err).NotTo(HaveOccurred())
 	_, err = insertOffers()
 	Expect(err).NotTo(HaveOccurred())
+}
+
+func initOfferGroupPostsCollection() {
+	offerGroupPostsCollection = db.NewOfferGroupPosts(dbClient)
 }
 
 func initTagsCollection() {

--- a/db/mocks_test.go
+++ b/db/mocks_test.go
@@ -49,6 +49,7 @@ func createMocks() *Mocks {
 			&model.Offer{
 				CommonOfferFields: model.CommonOfferFields{
 					Restaurant: model.OfferRestaurant{
+						ID:     bson.NewObjectId(),
 						Name:   "Bulgarian Dude",
 						Region: "Tallinn",
 						Location: model.Location{
@@ -69,6 +70,7 @@ func createMocks() *Mocks {
 			&model.Offer{
 				CommonOfferFields: model.CommonOfferFields{
 					Restaurant: model.OfferRestaurant{
+						ID:     bson.NewObjectId(),
 						Name:   "Caesarian Kitchen",
 						Region: "Tartu",
 						Location: model.Location{

--- a/db/mocks_test.go
+++ b/db/mocks_test.go
@@ -28,6 +28,7 @@ func createMocks() *Mocks {
 			&model.Offer{
 				CommonOfferFields: model.CommonOfferFields{
 					Restaurant: model.OfferRestaurant{
+						ID:     restaurantID,
 						Name:   "Asian Chef",
 						Region: "Tartu",
 						Location: model.Location{

--- a/db/model/model_suite_test.go
+++ b/db/model/model_suite_test.go
@@ -1,0 +1,13 @@
+package model_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestModel(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Model Suite")
+}

--- a/db/model/offer.go
+++ b/db/model/offer.go
@@ -18,7 +18,6 @@ type (
 		Ingredients []string        `json:"ingredients"          bson:"ingredients"`
 		Price       float64         `json:"price"                bson:"price"`
 		Tags        []string        `json:"tags"                 bson:"tags"`
-		FBPostID    string          `json:"fb_post_id,omitempty" bson:"fb_post_id,omitempty"`
 	}
 
 	// Offer provides the mapping to the offers as represented in the DB

--- a/db/model/offer.go
+++ b/db/model/offer.go
@@ -50,11 +50,12 @@ type (
 	// OfferRestaurant holds the information about the restaurant that gets included
 	// in every offer
 	OfferRestaurant struct {
-		Name     string   `json:"name"     bson:"name"`
-		Region   string   `json:"region"   bson:"region"`
-		Address  string   `json:"address"  bson:"address"`
-		Location Location `json:"location" bson:"location"`
-		Phone    string   `json:"phone"    bson:"phone"`
+		ID       bson.ObjectId `json:"id"       bson:"id"`
+		Name     string        `json:"name"     bson:"name"`
+		Region   string        `json:"region"   bson:"region"`
+		Address  string        `json:"address"  bson:"address"`
+		Location Location      `json:"location" bson:"location"`
+		Phone    string        `json:"phone"    bson:"phone"`
 	}
 
 	// OfferRestaurantWithDistance wraps an OfferRestaurant and adds a distance field.

--- a/db/model/offer_group_post.go
+++ b/db/model/offer_group_post.go
@@ -26,3 +26,8 @@ func DateFromTime(t time.Time) DateWithoutTime {
 	dateString := t.Format(dateWithoutTimeLayout)
 	return DateWithoutTime(dateString)
 }
+
+func (d DateWithoutTime) IsValid() bool {
+	_, err := time.Parse(dateWithoutTimeLayout, string(d))
+	return err == nil
+}

--- a/db/model/offer_group_post.go
+++ b/db/model/offer_group_post.go
@@ -13,16 +13,16 @@ type (
 		ID              bson.ObjectId   `json:"_id,omitempty"        bson:"_id,omitempty"`
 		RestaurantID    bson.ObjectId   `json:"restaurant_id"        bson:"restaurant_id"`
 		MessageTemplate string          `json:"message_template"     bson:"message_template"`
-		Date            dateWithoutTime `json:"date"                 bson:"date"`
+		Date            DateWithoutTime `json:"date"                 bson:"date"`
 		FBPostID        string          `json:"fb_post_id,omitempty" bson:"fb_post_id,omitempty"`
 	}
 
-	dateWithoutTime string
+	DateWithoutTime string
 )
 
 const dateWithoutTimeLayout = "2006-01-02"
 
-func DateWithoutTime(t time.Time) dateWithoutTime {
+func DateFromTime(t time.Time) DateWithoutTime {
 	dateString := t.Format(dateWithoutTimeLayout)
-	return dateWithoutTime(dateString)
+	return DateWithoutTime(dateString)
 }

--- a/db/model/offer_group_post.go
+++ b/db/model/offer_group_post.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"time"
+
+	"gopkg.in/mgo.v2/bson"
+)
+
+const OfferGroupPostCollectionName = "offer_group_post"
+
+type (
+	OfferGroupPost struct {
+		ID              bson.ObjectId   `json:"_id,omitempty"        bson:"_id,omitempty"`
+		RestaurantID    bson.ObjectId   `json:"restaurant_id"        bson:"restaurant_id"`
+		MessageTemplate string          `json:"message_template"     bson:"message_template"`
+		Date            dateWithoutTime `json:"date"                 bson:"date"`
+		FBPostID        string          `json:"fb_post_id,omitempty" bson:"fb_post_id,omitempty"`
+	}
+
+	dateWithoutTime string
+)
+
+const dateWithoutTimeLayout = "2006-01-02"
+
+func DateWithoutTime(t time.Time) dateWithoutTime {
+	dateString := t.Format(dateWithoutTimeLayout)
+	return dateWithoutTime(dateString)
+}

--- a/db/model/offer_group_post.go
+++ b/db/model/offer_group_post.go
@@ -32,3 +32,12 @@ func (d DateWithoutTime) IsValid() bool {
 	_, err := time.Parse(dateWithoutTimeLayout, string(d))
 	return err == nil
 }
+
+func (d DateWithoutTime) TimeBounds(location *time.Location) (time.Time, time.Time, error) {
+	startTime, err := time.ParseInLocation(dateWithoutTimeLayout, string(d), location)
+	if err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+	endTime := startTime.AddDate(0, 0, 1)
+	return startTime, endTime, nil
+}

--- a/db/model/offer_group_post.go
+++ b/db/model/offer_group_post.go
@@ -10,11 +10,12 @@ const OfferGroupPostCollectionName = "offer_group_post"
 
 type (
 	OfferGroupPost struct {
-		ID              bson.ObjectId   `json:"_id,omitempty"        bson:"_id,omitempty"`
-		RestaurantID    bson.ObjectId   `json:"restaurant_id"        bson:"restaurant_id"`
-		MessageTemplate string          `json:"message_template"     bson:"message_template"`
-		Date            DateWithoutTime `json:"date"                 bson:"date"`
-		FBPostID        string          `json:"fb_post_id,omitempty" bson:"fb_post_id,omitempty"`
+		ID           bson.ObjectId   `json:"_id,omitempty"        bson:"_id,omitempty"`
+		RestaurantID bson.ObjectId   `json:"restaurant_id"        bson:"restaurant_id"`
+		Date         DateWithoutTime `json:"date"                 bson:"date"`
+
+		MessageTemplate string `json:"message_template"     bson:"message_template"`
+		FBPostID        string `json:"fb_post_id,omitempty" bson:"fb_post_id,omitempty"`
 	}
 
 	DateWithoutTime string

--- a/db/model/offer_group_post_test.go
+++ b/db/model/offer_group_post_test.go
@@ -1,0 +1,28 @@
+package model_test
+
+import (
+	"time"
+
+	"github.com/Lunchr/luncher-api/db/model"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("OfferGroupPost", func() {
+	Describe("DateWithoutTime", func() {
+		It("returns the date in the correct layout", func() {
+			t := time.Date(2011, time.January, 2, 0, 0, 0, 1, time.UTC)
+			result := model.DateWithoutTime(t)
+			Expect(string(result)).To(Equal("2011-01-02"))
+		})
+
+		It("plays well with other timezones", func() {
+			location, err := time.LoadLocation("Europe/Tallinn")
+			Expect(err).NotTo(HaveOccurred())
+			t := time.Date(2011, time.January, 2, 0, 0, 0, 1, location)
+			result := model.DateWithoutTime(t)
+			Expect(string(result)).To(Equal("2011-01-02"))
+		})
+	})
+})

--- a/db/model/offer_group_post_test.go
+++ b/db/model/offer_group_post_test.go
@@ -13,7 +13,7 @@ var _ = Describe("OfferGroupPost", func() {
 	Describe("DateWithoutTime", func() {
 		It("returns the date in the correct layout", func() {
 			t := time.Date(2011, time.January, 2, 0, 0, 0, 1, time.UTC)
-			result := model.DateWithoutTime(t)
+			result := model.DateFromTime(t)
 			Expect(string(result)).To(Equal("2011-01-02"))
 		})
 
@@ -21,7 +21,7 @@ var _ = Describe("OfferGroupPost", func() {
 			location, err := time.LoadLocation("Europe/Tallinn")
 			Expect(err).NotTo(HaveOccurred())
 			t := time.Date(2011, time.January, 2, 0, 0, 0, 1, location)
-			result := model.DateWithoutTime(t)
+			result := model.DateFromTime(t)
 			Expect(string(result)).To(Equal("2011-01-02"))
 		})
 	})

--- a/db/model/offer_group_post_test.go
+++ b/db/model/offer_group_post_test.go
@@ -43,5 +43,33 @@ var _ = Describe("OfferGroupPost", func() {
 				Expect(date.IsValid()).To(BeFalse())
 			})
 		})
+
+		Describe("TimeBounds", func() {
+			It("returns correct bounds for valid data", func() {
+				date := model.DateWithoutTime("2015-11-18")
+				startTime, endTime, err := date.TimeBounds(time.UTC)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(startTime).To(Equal(time.Date(2015, 11, 18, 0, 0, 0, 0, time.UTC)))
+				Expect(endTime).To(Equal(time.Date(2015, 11, 19, 0, 0, 0, 0, time.UTC)))
+			})
+
+			It("behaves well in different timezones", func() {
+				location, err := time.LoadLocation("America/New_York")
+				Expect(err).NotTo(HaveOccurred())
+				date := model.DateWithoutTime("2015-11-18")
+
+				startTime, endTime, err := date.TimeBounds(location)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(startTime).To(Equal(time.Date(2015, 11, 18, 0, 0, 0, 0, location)))
+				Expect(endTime).To(Equal(time.Date(2015, 11, 19, 0, 0, 0, 0, location)))
+			})
+
+			It("fails for invalid dates", func() {
+				date := model.DateWithoutTime("2015-71-18")
+				_, _, err := date.TimeBounds(time.UTC)
+				Expect(err).To(HaveOccurred())
+			})
+		})
 	})
 })

--- a/db/model/offer_group_post_test.go
+++ b/db/model/offer_group_post_test.go
@@ -11,18 +11,37 @@ import (
 
 var _ = Describe("OfferGroupPost", func() {
 	Describe("DateWithoutTime", func() {
-		It("returns the date in the correct layout", func() {
-			t := time.Date(2011, time.January, 2, 0, 0, 0, 1, time.UTC)
-			result := model.DateFromTime(t)
-			Expect(string(result)).To(Equal("2011-01-02"))
+		Describe("DateFromTime", func() {
+			It("returns the date in the correct layout", func() {
+				t := time.Date(2011, time.January, 2, 0, 0, 0, 1, time.UTC)
+				result := model.DateFromTime(t)
+				Expect(string(result)).To(Equal("2011-01-02"))
+			})
+
+			It("plays well with other timezones", func() {
+				location, err := time.LoadLocation("Europe/Tallinn")
+				Expect(err).NotTo(HaveOccurred())
+				t := time.Date(2011, time.January, 2, 0, 0, 0, 1, location)
+				result := model.DateFromTime(t)
+				Expect(string(result)).To(Equal("2011-01-02"))
+			})
 		})
 
-		It("plays well with other timezones", func() {
-			location, err := time.LoadLocation("Europe/Tallinn")
-			Expect(err).NotTo(HaveOccurred())
-			t := time.Date(2011, time.January, 2, 0, 0, 0, 1, location)
-			result := model.DateFromTime(t)
-			Expect(string(result)).To(Equal("2011-01-02"))
+		Describe("IsValid", func() {
+			It("returns true for a valid date", func() {
+				date := model.DateWithoutTime("2015-11-18")
+				Expect(date.IsValid()).To(BeTrue())
+			})
+
+			It("returns false for an invalid date", func() {
+				date := model.DateWithoutTime("2015-18-11")
+				Expect(date.IsValid()).To(BeFalse())
+			})
+
+			It("returns false for gibberish strings", func() {
+				date := model.DateWithoutTime("asdfasdfasjksdlaf")
+				Expect(date.IsValid()).To(BeFalse())
+			})
 		})
 	})
 })

--- a/db/model/restaurant.go
+++ b/db/model/restaurant.go
@@ -18,6 +18,8 @@ type (
 		Email          string        `json:"email,omitempty"            bson:"email,omitempty"`
 		Website        string        `json:"website,omitempty"          bson:"website,omitempty"`
 		FacebookPageID string        `json:"facebook_page_id,omitempty" bson:"facebook_page_id,omitempty"`
+
+		DefaultGroupPostMessageTemplate string `json:"default_group_post_message_template" bson:"default_group_post_message_template"`
 	}
 
 	// Location is a (limited) representation of a GeoJSON object

--- a/db/offer_group_posts.go
+++ b/db/offer_group_posts.go
@@ -8,6 +8,8 @@ import (
 
 type OfferGroupPosts interface {
 	Insert(...*model.OfferGroupPost) ([]*model.OfferGroupPost, error)
+	UpdateByID(bson.ObjectId, *model.OfferGroupPost) error
+	GetByID(bson.ObjectId) (*model.OfferGroupPost, error)
 }
 
 type offerGroupPostCollection struct {
@@ -30,4 +32,14 @@ func (c offerGroupPostCollection) Insert(posts ...*model.OfferGroupPost) ([]*mod
 		docs[i] = post
 	}
 	return posts, c.Collection.Insert(docs...)
+}
+
+func (c offerGroupPostCollection) UpdateByID(id bson.ObjectId, post *model.OfferGroupPost) error {
+	return c.Collection.UpdateId(id, bson.M{"$set": post})
+}
+
+func (c offerGroupPostCollection) GetByID(id bson.ObjectId) (*model.OfferGroupPost, error) {
+	var post model.OfferGroupPost
+	err := c.FindId(id).One(&post)
+	return &post, err
 }

--- a/db/offer_group_posts.go
+++ b/db/offer_group_posts.go
@@ -1,0 +1,33 @@
+package db
+
+import (
+	"github.com/Lunchr/luncher-api/db/model"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+type OfferGroupPosts interface {
+	Insert(...*model.OfferGroupPost) ([]*model.OfferGroupPost, error)
+}
+
+type offerGroupPostCollection struct {
+	*mgo.Collection
+}
+
+func NewOfferGroupPosts(c *Client) OfferGroupPosts {
+	collection := c.database.C(model.OfferGroupPostCollectionName)
+	return &offerGroupPostCollection{collection}
+}
+
+func (c offerGroupPostCollection) Insert(posts ...*model.OfferGroupPost) ([]*model.OfferGroupPost, error) {
+	for _, offerGroupPost := range posts {
+		if offerGroupPost.ID == "" {
+			offerGroupPost.ID = bson.NewObjectId()
+		}
+	}
+	docs := make([]interface{}, len(posts))
+	for i, post := range posts {
+		docs[i] = post
+	}
+	return posts, c.Collection.Insert(docs...)
+}

--- a/db/offer_group_posts.go
+++ b/db/offer_group_posts.go
@@ -10,6 +10,7 @@ type OfferGroupPosts interface {
 	Insert(...*model.OfferGroupPost) ([]*model.OfferGroupPost, error)
 	UpdateByID(bson.ObjectId, *model.OfferGroupPost) error
 	GetByID(bson.ObjectId) (*model.OfferGroupPost, error)
+	GetByDate(model.DateWithoutTime, bson.ObjectId) (*model.OfferGroupPost, error)
 }
 
 type offerGroupPostCollection struct {
@@ -41,5 +42,14 @@ func (c offerGroupPostCollection) UpdateByID(id bson.ObjectId, post *model.Offer
 func (c offerGroupPostCollection) GetByID(id bson.ObjectId) (*model.OfferGroupPost, error) {
 	var post model.OfferGroupPost
 	err := c.FindId(id).One(&post)
+	return &post, err
+}
+
+func (c offerGroupPostCollection) GetByDate(date model.DateWithoutTime, restaurantID bson.ObjectId) (*model.OfferGroupPost, error) {
+	var post model.OfferGroupPost
+	err := c.Find(bson.M{
+		"date":          date,
+		"restaurant_id": restaurantID,
+	}).One(&post)
 	return &post, err
 }

--- a/db/offer_group_posts_test.go
+++ b/db/offer_group_posts_test.go
@@ -1,6 +1,8 @@
 package db_test
 
 import (
+	"time"
+
 	"github.com/Lunchr/luncher-api/db/model"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -62,6 +64,33 @@ var _ = Describe("OfferGroupPosts", func() {
 				result, err := offerGroupPostsCollection.GetByID(id)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.MessageTemplate).To(Equal("an updated message"))
+			})
+		})
+	})
+
+	Describe("GetByDate", func() {
+		var date = model.DateFromTime(time.Date(2115, 04, 03, 0, 0, 0, 0, time.UTC))
+		var restaurantID = bson.NewObjectId()
+		RebuildDBAfterEach()
+
+		It("fails if not found", func() {
+			_, err := offerGroupPostsCollection.GetByDate(date, restaurantID)
+			Expect(err).To(HaveOccurred())
+		})
+
+		Context("with an post with known ID inserted", func() {
+			BeforeEach(func() {
+				post := aPost()
+				post.Date = date
+				post.RestaurantID = restaurantID
+				_, err := offerGroupPostsCollection.Insert(post)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("returns the found post", func() {
+				result, err := offerGroupPostsCollection.GetByDate(date, restaurantID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
 			})
 		})
 	})

--- a/db/offer_group_posts_test.go
+++ b/db/offer_group_posts_test.go
@@ -1,0 +1,40 @@
+package db_test
+
+import (
+	"github.com/Lunchr/luncher-api/db/model"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"gopkg.in/mgo.v2/bson"
+)
+
+var _ = Describe("OfferGroupPosts", func() {
+
+	Describe("Insert", func() {
+		RebuildDBAfterEach()
+
+		var aPost = func() *model.OfferGroupPost {
+			return &model.OfferGroupPost{
+				RestaurantID: bson.NewObjectId(),
+			}
+		}
+
+		It("should return the posts with new IDs", func() {
+			posts, err := offerGroupPostsCollection.Insert(aPost(), aPost())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(posts).To(HaveLen(2))
+			Expect(posts[0].ID).NotTo(BeEmpty())
+			Expect(posts[1].ID).NotTo(BeEmpty())
+		})
+
+		It("should keep current ID if exists", func() {
+			id := bson.NewObjectId()
+			post := aPost()
+			post.ID = id
+			posts, err := offerGroupPostsCollection.Insert(post, aPost())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(posts).To(HaveLen(2))
+			Expect(posts[0].ID).To(Equal(id))
+			Expect(posts[1].ID).NotTo(Equal(id))
+		})
+	})
+})

--- a/db/offers.go
+++ b/db/offers.go
@@ -14,6 +14,7 @@ type Offers interface {
 	GetForRegion(region string, startTime, endTime time.Time) ([]*model.Offer, error)
 	GetNear(loc geo.Location, startTime, endTime time.Time) ([]*model.OfferWithDistance, error)
 	GetForRestaurant(restaurantName string, startTime time.Time) ([]*model.Offer, error)
+	GetForRestaurantWithinTimeBounds(restaurantName string, startTime, endTime time.Time) ([]*model.Offer, error)
 	UpdateID(bson.ObjectId, *model.Offer) error
 	GetID(bson.ObjectId) (*model.Offer, error)
 	RemoveID(bson.ObjectId) error
@@ -73,6 +74,20 @@ func (c offersCollection) GetForRegion(region string, startTime, endTime time.Ti
 func (c offersCollection) GetForRestaurant(restaurantName string, startTime time.Time) ([]*model.Offer, error) {
 	var offers []*model.Offer
 	err := c.Find(bson.M{
+		"to_time": bson.M{
+			"$gte": startTime,
+		},
+		"restaurant.name": restaurantName,
+	}).All(&offers)
+	return offers, err
+}
+
+func (c offersCollection) GetForRestaurantWithinTimeBounds(restaurantName string, startTime, endTime time.Time) ([]*model.Offer, error) {
+	var offers []*model.Offer
+	err := c.Find(bson.M{
+		"from_time": bson.M{
+			"$lte": endTime,
+		},
 		"to_time": bson.M{
 			"$gte": startTime,
 		},

--- a/db/offers.go
+++ b/db/offers.go
@@ -13,8 +13,8 @@ type Offers interface {
 	Insert(...*model.Offer) ([]*model.Offer, error)
 	GetForRegion(region string, startTime, endTime time.Time) ([]*model.Offer, error)
 	GetNear(loc geo.Location, startTime, endTime time.Time) ([]*model.OfferWithDistance, error)
-	GetForRestaurant(restaurantName string, startTime time.Time) ([]*model.Offer, error)
-	GetForRestaurantWithinTimeBounds(restaurantName string, startTime, endTime time.Time) ([]*model.Offer, error)
+	GetForRestaurant(restaurantID bson.ObjectId, startTime time.Time) ([]*model.Offer, error)
+	GetForRestaurantWithinTimeBounds(restaurantID bson.ObjectId, startTime, endTime time.Time) ([]*model.Offer, error)
 	UpdateID(bson.ObjectId, *model.Offer) error
 	GetID(bson.ObjectId) (*model.Offer, error)
 	RemoveID(bson.ObjectId) error
@@ -71,18 +71,18 @@ func (c offersCollection) GetForRegion(region string, startTime, endTime time.Ti
 	return offers, err
 }
 
-func (c offersCollection) GetForRestaurant(restaurantName string, startTime time.Time) ([]*model.Offer, error) {
+func (c offersCollection) GetForRestaurant(restaurantID bson.ObjectId, startTime time.Time) ([]*model.Offer, error) {
 	var offers []*model.Offer
 	err := c.Find(bson.M{
 		"to_time": bson.M{
 			"$gte": startTime,
 		},
-		"restaurant.name": restaurantName,
+		"restaurant.id": restaurantID,
 	}).All(&offers)
 	return offers, err
 }
 
-func (c offersCollection) GetForRestaurantWithinTimeBounds(restaurantName string, startTime, endTime time.Time) ([]*model.Offer, error) {
+func (c offersCollection) GetForRestaurantWithinTimeBounds(restaurantID bson.ObjectId, startTime, endTime time.Time) ([]*model.Offer, error) {
 	var offers []*model.Offer
 	err := c.Find(bson.M{
 		"from_time": bson.M{
@@ -91,7 +91,7 @@ func (c offersCollection) GetForRestaurantWithinTimeBounds(restaurantName string
 		"to_time": bson.M{
 			"$gte": startTime,
 		},
-		"restaurant.name": restaurantName,
+		"restaurant.id": restaurantID,
 	}).All(&offers)
 	return offers, err
 }

--- a/db/offers_test.go
+++ b/db/offers_test.go
@@ -21,6 +21,7 @@ var _ = Describe("Offers", func() {
 		return &model.Offer{
 			CommonOfferFields: model.CommonOfferFields{
 				Restaurant: model.OfferRestaurant{
+					ID: bson.NewObjectId(),
 					// The location is needed because otherwise the index will complain
 					Location: model.Location{
 						Type: "Point",

--- a/db/offers_test.go
+++ b/db/offers_test.go
@@ -141,6 +141,7 @@ var _ = Describe("Offers", func() {
 				}
 			}
 		)
+
 		Describe("time range", func() {
 			BeforeEach(func(done Done) {
 				defer close(done)
@@ -424,6 +425,40 @@ var _ = Describe("Offers", func() {
 
 			It("should NOT include the offer", func() {
 				offers, err := offersCollection.GetForRestaurant(restaurant, startTime)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(offers).To(HaveLen(0))
+			})
+		})
+	})
+
+	Describe("GetForRestaurantWithinTimeBounds", func() {
+		var (
+			startTime      time.Time
+			endTime        time.Time
+			restaurant     string
+			offerStartTime = time.Date(2014, 11, 10, 9, 0, 0, 0, time.UTC)
+			offerEndTime   = time.Date(2014, 11, 10, 11, 0, 0, 0, time.UTC)
+		)
+
+		Context("with an existing restaurant", func() {
+			BeforeEach(func() {
+				restaurant = "Asian Chef"
+			})
+
+			ItHandlesStartAndEndTime(func(startTime, endTime time.Time) ([]*model.Offer, error) {
+				return offersCollection.GetForRestaurantWithinTimeBounds(restaurant, startTime, endTime)
+			})
+		})
+
+		Context("with a non-existing restaurant", func() {
+			BeforeEach(func() {
+				restaurant = "something random"
+				startTime = offerStartTime.Add(-24 * 10 * time.Hour)
+				endTime = offerEndTime.Add(10 * time.Hour)
+			})
+
+			It("should NOT include the offer", func() {
+				offers, err := offersCollection.GetForRestaurantWithinTimeBounds(restaurant, startTime, endTime)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(offers).To(HaveLen(0))
 			})

--- a/db/offers_test.go
+++ b/db/offers_test.go
@@ -369,14 +369,14 @@ var _ = Describe("Offers", func() {
 	Describe("GetForRestaurant", func() {
 		var (
 			startTime      time.Time
-			restaurant     string
+			restaurantID   bson.ObjectId
 			offerStartTime = time.Date(2014, 11, 10, 9, 0, 0, 0, time.UTC)
 			offerEndTime   = time.Date(2014, 11, 10, 11, 0, 0, 0, time.UTC)
 		)
 
 		Context("with an existing restaurant", func() {
 			BeforeEach(func() {
-				restaurant = "Asian Chef"
+				restaurantID = mocks.restaurantID
 			})
 
 			Context("with time right before an offer", func() {
@@ -385,7 +385,7 @@ var _ = Describe("Offers", func() {
 				})
 
 				It("should include the offer", func() {
-					offers, err := offersCollection.GetForRestaurant(restaurant, startTime)
+					offers, err := offersCollection.GetForRestaurant(restaurantID, startTime)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(offers).To(HaveLen(1))
 					Expect(offers).To(ContainOfferMock(0))
@@ -398,7 +398,7 @@ var _ = Describe("Offers", func() {
 				})
 
 				It("should include the offer", func() {
-					offers, err := offersCollection.GetForRestaurant(restaurant, startTime)
+					offers, err := offersCollection.GetForRestaurant(restaurantID, startTime)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(offers).To(HaveLen(1))
 					Expect(offers).To(ContainOfferMock(0))
@@ -410,7 +410,7 @@ var _ = Describe("Offers", func() {
 				})
 
 				It("should NOT include the offer", func() {
-					offers, err := offersCollection.GetForRestaurant(restaurant, startTime)
+					offers, err := offersCollection.GetForRestaurant(restaurantID, startTime)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(offers).To(HaveLen(0))
 				})
@@ -419,12 +419,12 @@ var _ = Describe("Offers", func() {
 
 		Context("with a non-existing restaurant", func() {
 			BeforeEach(func() {
-				restaurant = "something random"
+				restaurantID = bson.ObjectId("somethingrnd")
 				startTime = offerStartTime.Add(-24 * 10 * time.Hour)
 			})
 
 			It("should NOT include the offer", func() {
-				offers, err := offersCollection.GetForRestaurant(restaurant, startTime)
+				offers, err := offersCollection.GetForRestaurant(restaurantID, startTime)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(offers).To(HaveLen(0))
 			})
@@ -435,30 +435,30 @@ var _ = Describe("Offers", func() {
 		var (
 			startTime      time.Time
 			endTime        time.Time
-			restaurant     string
+			restaurantID   bson.ObjectId
 			offerStartTime = time.Date(2014, 11, 10, 9, 0, 0, 0, time.UTC)
 			offerEndTime   = time.Date(2014, 11, 10, 11, 0, 0, 0, time.UTC)
 		)
 
 		Context("with an existing restaurant", func() {
 			BeforeEach(func() {
-				restaurant = "Asian Chef"
+				restaurantID = mocks.restaurantID
 			})
 
 			ItHandlesStartAndEndTime(func(startTime, endTime time.Time) ([]*model.Offer, error) {
-				return offersCollection.GetForRestaurantWithinTimeBounds(restaurant, startTime, endTime)
+				return offersCollection.GetForRestaurantWithinTimeBounds(restaurantID, startTime, endTime)
 			})
 		})
 
 		Context("with a non-existing restaurant", func() {
 			BeforeEach(func() {
-				restaurant = "something random"
+				restaurantID = bson.ObjectId("somethingrnd")
 				startTime = offerStartTime.Add(-24 * 10 * time.Hour)
 				endTime = offerEndTime.Add(10 * time.Hour)
 			})
 
 			It("should NOT include the offer", func() {
-				offers, err := offersCollection.GetForRestaurantWithinTimeBounds(restaurant, startTime, endTime)
+				offers, err := offersCollection.GetForRestaurantWithinTimeBounds(restaurantID, startTime, endTime)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(offers).To(HaveLen(0))
 			})

--- a/handler/mocks/OfferGroupPosts.go
+++ b/handler/mocks/OfferGroupPosts.go
@@ -1,0 +1,87 @@
+package mocks
+
+import "github.com/stretchr/testify/mock"
+
+import "github.com/Lunchr/luncher-api/db/model"
+
+import "gopkg.in/mgo.v2/bson"
+
+type OfferGroupPosts struct {
+	mock.Mock
+}
+
+func (_m *OfferGroupPosts) Insert(_a0 ...*model.OfferGroupPost) ([]*model.OfferGroupPost, error) {
+	ret := _m.Called(_a0)
+
+	var r0 []*model.OfferGroupPost
+	if rf, ok := ret.Get(0).(func(...*model.OfferGroupPost) []*model.OfferGroupPost); ok {
+		r0 = rf(_a0...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.OfferGroupPost)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(...*model.OfferGroupPost) error); ok {
+		r1 = rf(_a0...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *OfferGroupPosts) UpdateByID(_a0 bson.ObjectId, _a1 *model.OfferGroupPost) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(bson.ObjectId, *model.OfferGroupPost) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *OfferGroupPosts) GetByID(_a0 bson.ObjectId) (*model.OfferGroupPost, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *model.OfferGroupPost
+	if rf, ok := ret.Get(0).(func(bson.ObjectId) *model.OfferGroupPost); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.OfferGroupPost)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(bson.ObjectId) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *OfferGroupPosts) GetByDate(_a0 model.DateWithoutTime, _a1 bson.ObjectId) (*model.OfferGroupPost, error) {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 *model.OfferGroupPost
+	if rf, ok := ret.Get(0).(func(model.DateWithoutTime, bson.ObjectId) *model.OfferGroupPost); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.OfferGroupPost)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(model.DateWithoutTime, bson.ObjectId) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/handler/mocks/Offers.go
+++ b/handler/mocks/Offers.go
@@ -1,0 +1,164 @@
+package mocks
+
+import "github.com/stretchr/testify/mock"
+
+import "time"
+import "github.com/Lunchr/luncher-api/db/model"
+import "github.com/Lunchr/luncher-api/geo"
+
+import "gopkg.in/mgo.v2/bson"
+
+type Offers struct {
+	mock.Mock
+}
+
+func (_m *Offers) Insert(_a0 ...*model.Offer) ([]*model.Offer, error) {
+	ret := _m.Called(_a0)
+
+	var r0 []*model.Offer
+	if rf, ok := ret.Get(0).(func(...*model.Offer) []*model.Offer); ok {
+		r0 = rf(_a0...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.Offer)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(...*model.Offer) error); ok {
+		r1 = rf(_a0...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Offers) GetForRegion(region string, startTime time.Time, endTime time.Time) ([]*model.Offer, error) {
+	ret := _m.Called(region, startTime, endTime)
+
+	var r0 []*model.Offer
+	if rf, ok := ret.Get(0).(func(string, time.Time, time.Time) []*model.Offer); ok {
+		r0 = rf(region, startTime, endTime)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.Offer)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, time.Time, time.Time) error); ok {
+		r1 = rf(region, startTime, endTime)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Offers) GetNear(loc geo.Location, startTime time.Time, endTime time.Time) ([]*model.OfferWithDistance, error) {
+	ret := _m.Called(loc, startTime, endTime)
+
+	var r0 []*model.OfferWithDistance
+	if rf, ok := ret.Get(0).(func(geo.Location, time.Time, time.Time) []*model.OfferWithDistance); ok {
+		r0 = rf(loc, startTime, endTime)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.OfferWithDistance)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(geo.Location, time.Time, time.Time) error); ok {
+		r1 = rf(loc, startTime, endTime)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Offers) GetForRestaurant(restaurantID bson.ObjectId, startTime time.Time) ([]*model.Offer, error) {
+	ret := _m.Called(restaurantID, startTime)
+
+	var r0 []*model.Offer
+	if rf, ok := ret.Get(0).(func(bson.ObjectId, time.Time) []*model.Offer); ok {
+		r0 = rf(restaurantID, startTime)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.Offer)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(bson.ObjectId, time.Time) error); ok {
+		r1 = rf(restaurantID, startTime)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Offers) GetForRestaurantWithinTimeBounds(restaurantID bson.ObjectId, startTime time.Time, endTime time.Time) ([]*model.Offer, error) {
+	ret := _m.Called(restaurantID, startTime, endTime)
+
+	var r0 []*model.Offer
+	if rf, ok := ret.Get(0).(func(bson.ObjectId, time.Time, time.Time) []*model.Offer); ok {
+		r0 = rf(restaurantID, startTime, endTime)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.Offer)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(bson.ObjectId, time.Time, time.Time) error); ok {
+		r1 = rf(restaurantID, startTime, endTime)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Offers) UpdateID(_a0 bson.ObjectId, _a1 *model.Offer) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(bson.ObjectId, *model.Offer) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *Offers) GetID(_a0 bson.ObjectId) (*model.Offer, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *model.Offer
+	if rf, ok := ret.Get(0).(func(bson.ObjectId) *model.Offer); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.Offer)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(bson.ObjectId) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Offers) RemoveID(_a0 bson.ObjectId) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(bson.ObjectId) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/handler/mocks/Regions.go
+++ b/handler/mocks/Regions.go
@@ -1,0 +1,68 @@
+package mocks
+
+import "github.com/Lunchr/luncher-api/db"
+import "github.com/stretchr/testify/mock"
+
+import "github.com/Lunchr/luncher-api/db/model"
+
+type Regions struct {
+	mock.Mock
+}
+
+func (_m *Regions) Insert(_a0 ...*model.Region) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(...*model.Region) error); ok {
+		r0 = rf(_a0...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *Regions) GetName(_a0 string) (*model.Region, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *model.Region
+	if rf, ok := ret.Get(0).(func(string) *model.Region); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.Region)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Regions) GetAll() db.RegionIter {
+	ret := _m.Called()
+
+	var r0 db.RegionIter
+	if rf, ok := ret.Get(0).(func() db.RegionIter); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(db.RegionIter)
+	}
+
+	return r0
+}
+func (_m *Regions) UpdateName(_a0 string, _a1 *model.Region) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, *model.Region) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/handler/offer_group_post_handler.go
+++ b/handler/offer_group_post_handler.go
@@ -145,13 +145,6 @@ func updateGroupPost(post *model.OfferGroupPost, user *model.User, restaurant *m
 		return nil
 	}
 	fbAPI := fbAuth.APIConnection(&user.Session.FacebookUserToken)
-	offersForDate, handlerErr := getOffersForDate(post.Date, restaurant, offers, regions)
-	if handlerErr != nil {
-		return handlerErr
-	} else if len(offersForDate) == 0 {
-		return nil
-	}
-	message := formFBMessage(post, offersForDate)
 	// Remove the current post from FB, if it's already there
 	if post.FBPostID != "" {
 		err := fbAPI.PostDelete(user.Session.FacebookPageToken, post.FBPostID)
@@ -159,6 +152,13 @@ func updateGroupPost(post *model.OfferGroupPost, user *model.User, restaurant *m
 			return router.NewHandlerError(err, "Failed to delete the current post from Facebook", http.StatusBadGateway)
 		}
 	}
+	offersForDate, handlerErr := getOffersForDate(post.Date, restaurant, offers, regions)
+	if handlerErr != nil {
+		return handlerErr
+	} else if len(offersForDate) == 0 {
+		return nil
+	}
+	message := formFBMessage(post, offersForDate)
 	// Add the new version
 	fbPost, err := fbAPI.PagePublish(user.Session.FacebookPageToken, restaurant.FacebookPageID, message)
 	if err != nil {

--- a/handler/offer_group_post_handler.go
+++ b/handler/offer_group_post_handler.go
@@ -1,0 +1,43 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/Lunchr/luncher-api/db"
+	"github.com/Lunchr/luncher-api/db/model"
+	"github.com/Lunchr/luncher-api/router"
+	"github.com/Lunchr/luncher-api/session"
+	"github.com/julienschmidt/httprouter"
+)
+
+// OfferGroupPost handles GET requests to /restaurant/post/:date. It returns all current day's offers for the region.
+func OfferGroupPost(c db.OfferGroupPosts, sessionManager session.Manager, users db.Users, restaurants db.Restaurants) router.HandlerWithParams {
+	handler := func(w http.ResponseWriter, r *http.Request, user *model.User, restaurant *model.Restaurant,
+		date model.DateWithoutTime) *router.HandlerError {
+		post, err := c.GetByDate(date, restaurant.ID)
+		if err != nil {
+			return router.NewHandlerError(err, "An error occured while trying to fetch a offer group post", http.StatusInternalServerError)
+		}
+		return writeJSON(w, post)
+	}
+	return forDate(sessionManager, users, restaurants, handler)
+}
+
+type HandlerWithRestaurantAndDate func(w http.ResponseWriter, r *http.Request, user *model.User, restaurant *model.Restaurant,
+	date model.DateWithoutTime) *router.HandlerError
+
+func forDate(sessionManager session.Manager, users db.Users, restaurants db.Restaurants,
+	handler HandlerWithRestaurantAndDate) router.HandlerWithParams {
+	handlerWithRestaurant := func(w http.ResponseWriter, r *http.Request, ps httprouter.Params, user *model.User,
+		restaurant *model.Restaurant) *router.HandlerError {
+		date := model.DateWithoutTime(ps.ByName("date"))
+		if date == "" {
+			return router.NewStringHandlerError("Date not specified!", "Please specify a date", http.StatusBadRequest)
+		}
+		if !date.IsValid() {
+			return router.NewSimpleHandlerError("Invalid date specified", http.StatusBadRequest)
+		}
+		return handler(w, r, user, restaurant, date)
+	}
+	return forRestaurantWithParams(sessionManager, users, restaurants, handlerWithRestaurant)
+}

--- a/handler/offer_group_post_handler.go
+++ b/handler/offer_group_post_handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 
 	"github.com/Lunchr/luncher-api/db"
 	"github.com/Lunchr/luncher-api/db/model"
@@ -44,6 +45,26 @@ func PostOfferGroupPost(c db.OfferGroupPosts, sessionManager session.Manager, us
 	return forRestaurant(sessionManager, users, restaurants, handler)
 }
 
+// PutOfferGroupPost handles PUT requests to /restaurant/posts/:date. It stores the info in the DB and updates the post in FB.
+func PutOfferGroupPost(c db.OfferGroupPosts, sessionManager session.Manager, users db.Users, restaurants db.Restaurants) router.HandlerWithParams {
+	handler := func(w http.ResponseWriter, r *http.Request, user *model.User, restaurant *model.Restaurant,
+		date model.DateWithoutTime) *router.HandlerError {
+		post, handlerErr := parseOfferGroupPost(r, restaurant)
+		if handlerErr != nil {
+			return handlerErr
+		}
+		if post.Date != date {
+			return router.NewSimpleHandlerError("Unexpected date value", http.StatusBadRequest)
+		}
+		err := c.UpdateByID(post.ID, post)
+		if err != nil {
+			return router.NewSimpleHandlerError("Failed to insert the post to DB", http.StatusBadRequest)
+		}
+		return writeJSON(w, post)
+	}
+	return forDate(sessionManager, users, restaurants, handler)
+}
+
 type HandlerWithRestaurantAndDate func(w http.ResponseWriter, r *http.Request, user *model.User, restaurant *model.Restaurant,
 	date model.DateWithoutTime) *router.HandlerError
 
@@ -65,8 +86,9 @@ func forDate(sessionManager session.Manager, users db.Users, restaurants db.Rest
 
 func parseOfferGroupPost(r *http.Request, restaurant *model.Restaurant) (*model.OfferGroupPost, *router.HandlerError) {
 	var post struct {
-		MessageTemplate string `json:"message_template"`
-		Date            string `json:"date"`
+		ID              bson.ObjectId `json:"_id"`
+		MessageTemplate string        `json:"message_template"`
+		Date            string        `json:"date"`
 	}
 	err := json.NewDecoder(r.Body).Decode(&post)
 	if err != nil {
@@ -80,6 +102,7 @@ func parseOfferGroupPost(r *http.Request, restaurant *model.Restaurant) (*model.
 		return nil, router.NewSimpleHandlerError("Invalid date specified", http.StatusBadRequest)
 	}
 	return &model.OfferGroupPost{
+		ID:              post.ID,
 		MessageTemplate: post.MessageTemplate,
 		Date:            date,
 		RestaurantID:    restaurant.ID,

--- a/handler/offer_group_post_handler.go
+++ b/handler/offer_group_post_handler.go
@@ -3,6 +3,8 @@ package handler
 import (
 	"net/http"
 
+	"gopkg.in/mgo.v2"
+
 	"github.com/Lunchr/luncher-api/db"
 	"github.com/Lunchr/luncher-api/db/model"
 	"github.com/Lunchr/luncher-api/router"
@@ -15,7 +17,9 @@ func OfferGroupPost(c db.OfferGroupPosts, sessionManager session.Manager, users 
 	handler := func(w http.ResponseWriter, r *http.Request, user *model.User, restaurant *model.Restaurant,
 		date model.DateWithoutTime) *router.HandlerError {
 		post, err := c.GetByDate(date, restaurant.ID)
-		if err != nil {
+		if err == mgo.ErrNotFound {
+			return router.NewHandlerError(err, "Offer group post not found", http.StatusNotFound)
+		} else if err != nil {
 			return router.NewHandlerError(err, "An error occured while trying to fetch a offer group post", http.StatusInternalServerError)
 		}
 		return writeJSON(w, post)

--- a/handler/offer_group_post_handler.go
+++ b/handler/offer_group_post_handler.go
@@ -12,7 +12,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
-// OfferGroupPost handles GET requests to /restaurant/post/:date. It returns all current day's offers for the region.
+// OfferGroupPost handles GET requests to /restaurant/posts/:date. It returns all current day's offers for the region.
 func OfferGroupPost(c db.OfferGroupPosts, sessionManager session.Manager, users db.Users, restaurants db.Restaurants) router.HandlerWithParams {
 	handler := func(w http.ResponseWriter, r *http.Request, user *model.User, restaurant *model.Restaurant,
 		date model.DateWithoutTime) *router.HandlerError {

--- a/handler/offer_group_post_handler_test.go
+++ b/handler/offer_group_post_handler_test.go
@@ -1,0 +1,120 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/Lunchr/luncher-api/db"
+	"github.com/Lunchr/luncher-api/db/model"
+	. "github.com/Lunchr/luncher-api/handler"
+	"github.com/Lunchr/luncher-api/handler/mocks"
+	"github.com/Lunchr/luncher-api/router"
+	"github.com/Lunchr/luncher-api/session"
+	"github.com/julienschmidt/httprouter"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
+	"gopkg.in/mgo.v2/bson"
+)
+
+var _ = Describe("OfferGroupPostHandlers", func() {
+	Describe("GET /restaurant/post/:date", func() {
+		var (
+			sessionManager        session.Manager
+			postsCollection       db.OfferGroupPosts
+			restaurantsCollection db.Restaurants
+			usersCollection       db.Users
+			handler               router.HandlerWithParams
+		)
+
+		JustBeforeEach(func() {
+			handler = OfferGroupPost(postsCollection, sessionManager, usersCollection, restaurantsCollection)
+		})
+
+		ExpectUserToBeLoggedIn(func() *router.HandlerError {
+			return handler(responseRecorder, request, nil)
+		}, func(mgr session.Manager, users db.Users) {
+			sessionManager = mgr
+			usersCollection = users
+		})
+
+		Context("with session set and a matching user in DB", func() {
+			var (
+				mockSessionManager        *mocks.Manager
+				mockPostsCollection       *mocks.OfferGroupPosts
+				mockRestaurantsCollection *mocks.Restaurants
+				mockUsersCollection       *mocks.Users
+				params                    httprouter.Params
+				restaurantID              bson.ObjectId
+			)
+
+			BeforeEach(func() {
+				mockSessionManager = new(mocks.Manager)
+				sessionManager = mockSessionManager
+				mockPostsCollection = new(mocks.OfferGroupPosts)
+				postsCollection = mockPostsCollection
+				mockRestaurantsCollection = new(mocks.Restaurants)
+				restaurantsCollection = mockRestaurantsCollection
+				mockUsersCollection = new(mocks.Users)
+				usersCollection = mockUsersCollection
+
+				restaurantID = bson.NewObjectId()
+				restaurant := &model.Restaurant{
+					ID: restaurantID,
+				}
+				user := &model.User{
+					RestaurantIDs: []bson.ObjectId{restaurant.ID},
+				}
+
+				mockSessionManager.On("Get", mock.Anything).Return("session", nil)
+				mockUsersCollection.On("GetSessionID", "session").Return(user, nil)
+				mockRestaurantsCollection.On("GetID", restaurantID).Return(restaurant, nil)
+
+				params = httprouter.Params{httprouter.Param{
+					Key:   "date",
+					Value: "2015-04-10",
+				}}
+			})
+
+			Context("with db returning a proper result", func() {
+				BeforeEach(func() {
+					post := &model.OfferGroupPost{
+						MessageTemplate: "this is a message template %%",
+					}
+					mockPostsCollection.On("GetByDate", model.DateWithoutTime("2015-04-10"), restaurantID).Return(post, nil)
+				})
+
+				It("should succeed", func() {
+					err := handler(responseRecorder, request, params)
+					Expect(err).To(BeNil())
+				})
+
+				It("should return json", func() {
+					handler(responseRecorder, request, params)
+					contentTypes := responseRecorder.HeaderMap["Content-Type"]
+					Expect(contentTypes).To(HaveLen(1))
+					Expect(contentTypes[0]).To(Equal("application/json"))
+				})
+
+				It("should include the offers in the response", func() {
+					handler(responseRecorder, request, params)
+					var result *model.OfferGroupPost
+					json.Unmarshal(responseRecorder.Body.Bytes(), &result)
+					Expect(result.MessageTemplate).To(Equal("this is a message template %%"))
+				})
+			})
+
+			Context("with db returning an error", func() {
+				BeforeEach(func() {
+					mockPostsCollection.On("GetByDate", model.DateWithoutTime("2015-04-10"), restaurantID).Return(nil,
+						errors.New("idk man, things happened"))
+				})
+
+				It("should fail", func() {
+					err := handler(responseRecorder, request, params)
+					Expect(err).NotTo(BeNil())
+				})
+			})
+		})
+	})
+})

--- a/handler/offer_group_post_handler_test.go
+++ b/handler/offer_group_post_handler_test.go
@@ -77,6 +77,13 @@ var _ = Describe("OfferGroupPostHandlers", func() {
 				}}
 			})
 
+			AfterEach(func() {
+				mockSessionManager.AssertExpectations(GinkgoT())
+				mockPostsCollection.AssertExpectations(GinkgoT())
+				mockRestaurantsCollection.AssertExpectations(GinkgoT())
+				mockUsersCollection.AssertExpectations(GinkgoT())
+			})
+
 			Context("with db returning a proper result", func() {
 				BeforeEach(func() {
 					post := &model.OfferGroupPost{
@@ -127,6 +134,132 @@ var _ = Describe("OfferGroupPostHandlers", func() {
 					err := handler(responseRecorder, request, params)
 					Expect(err).NotTo(BeNil())
 					Expect(err.Code).To(Equal(404))
+				})
+			})
+		})
+	})
+
+	Describe("POST /restaurant/posts", func() {
+		var (
+			sessionManager        session.Manager
+			postsCollection       db.OfferGroupPosts
+			restaurantsCollection db.Restaurants
+			usersCollection       db.Users
+			handler               router.Handler
+		)
+
+		JustBeforeEach(func() {
+			handler = PostOfferGroupPost(postsCollection, sessionManager, usersCollection, restaurantsCollection)
+		})
+
+		ExpectUserToBeLoggedIn(func() *router.HandlerError {
+			return handler(responseRecorder, request)
+		}, func(mgr session.Manager, users db.Users) {
+			sessionManager = mgr
+			usersCollection = users
+		})
+
+		Context("with session set and a matching user in DB", func() {
+			var (
+				mockSessionManager        *mocks.Manager
+				mockPostsCollection       *mocks.OfferGroupPosts
+				mockRestaurantsCollection *mocks.Restaurants
+				mockUsersCollection       *mocks.Users
+				restaurantID              bson.ObjectId
+				id                        bson.ObjectId
+			)
+
+			BeforeEach(func() {
+				mockSessionManager = new(mocks.Manager)
+				sessionManager = mockSessionManager
+				mockPostsCollection = new(mocks.OfferGroupPosts)
+				postsCollection = mockPostsCollection
+				mockRestaurantsCollection = new(mocks.Restaurants)
+				restaurantsCollection = mockRestaurantsCollection
+				mockUsersCollection = new(mocks.Users)
+				usersCollection = mockUsersCollection
+				id = bson.NewObjectId()
+
+				restaurantID = bson.NewObjectId()
+				restaurant := &model.Restaurant{
+					ID: restaurantID,
+				}
+				user := &model.User{
+					RestaurantIDs: []bson.ObjectId{restaurant.ID},
+				}
+
+				mockSessionManager.On("Get", mock.Anything).Return("session", nil)
+				mockUsersCollection.On("GetSessionID", "session").Return(user, nil)
+				mockRestaurantsCollection.On("GetID", restaurantID).Return(restaurant, nil)
+
+				requestMethod = "POST"
+			})
+
+			AfterEach(func() {
+				mockSessionManager.AssertExpectations(GinkgoT())
+				mockPostsCollection.AssertExpectations(GinkgoT())
+				mockRestaurantsCollection.AssertExpectations(GinkgoT())
+				mockUsersCollection.AssertExpectations(GinkgoT())
+			})
+
+			Context("with valid input", func() {
+				BeforeEach(func() {
+					requestData = map[string]interface{}{
+						"date": "2115-04-18",
+					}
+				})
+
+				Context("with DB update succeeding", func() {
+					BeforeEach(func() {
+						mockPostsCollection.On("Insert", mock.AnythingOfType("[]*model.OfferGroupPost")).Return([]*model.OfferGroupPost{
+							&model.OfferGroupPost{
+								ID: id,
+							},
+						}, nil)
+					})
+
+					It("should succeed", func() {
+						err := handler(responseRecorder, request)
+						Expect(err).To(BeNil())
+					})
+
+					It("should return json", func() {
+						handler(responseRecorder, request)
+						contentTypes := responseRecorder.HeaderMap["Content-Type"]
+						Expect(contentTypes).To(HaveLen(1))
+						Expect(contentTypes[0]).To(Equal("application/json"))
+					})
+
+					It("should include the restaurant with the new ID", func() {
+						handler(responseRecorder, request)
+						var post *model.OfferGroupPost
+						json.Unmarshal(responseRecorder.Body.Bytes(), &post)
+						Expect(post.ID).To(Equal(id))
+					})
+				})
+
+				Context("with DB update failing", func() {
+					BeforeEach(func() {
+						mockPostsCollection.On("Insert", mock.AnythingOfType("[]*model.OfferGroupPost")).Return(nil, errors.New("things"))
+					})
+
+					It("should fail", func() {
+						err := handler(responseRecorder, request)
+						Expect(err).NotTo(BeNil())
+					})
+				})
+			})
+
+			Context("with an invalid date", func() {
+				BeforeEach(func() {
+					requestData = map[string]interface{}{
+						"date": "2115-74-18",
+					}
+				})
+
+				It("should fail", func() {
+					err := handler(responseRecorder, request)
+					Expect(err).NotTo(BeNil())
 				})
 			})
 		})

--- a/handler/offer_group_post_handler_test.go
+++ b/handler/offer_group_post_handler_test.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
+	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -113,6 +114,19 @@ var _ = Describe("OfferGroupPostHandlers", func() {
 				It("should fail", func() {
 					err := handler(responseRecorder, request, params)
 					Expect(err).NotTo(BeNil())
+				})
+			})
+
+			Context("with db returning a NotFound error", func() {
+				BeforeEach(func() {
+					mockPostsCollection.On("GetByDate", model.DateWithoutTime("2015-04-10"), restaurantID).Return(nil,
+						mgo.ErrNotFound)
+				})
+
+				It("should fail with 404", func() {
+					err := handler(responseRecorder, request, params)
+					Expect(err).NotTo(BeNil())
+					Expect(err.Code).To(Equal(404))
 				})
 			})
 		})

--- a/handler/offer_group_post_handler_test.go
+++ b/handler/offer_group_post_handler_test.go
@@ -230,7 +230,7 @@ var _ = Describe("OfferGroupPostHandlers", func() {
 						Expect(contentTypes[0]).To(Equal("application/json"))
 					})
 
-					It("should include the restaurant with the new ID", func() {
+					It("should include the post with the new ID", func() {
 						handler(responseRecorder, request)
 						var post *model.OfferGroupPost
 						json.Unmarshal(responseRecorder.Body.Bytes(), &post)
@@ -259,6 +259,155 @@ var _ = Describe("OfferGroupPostHandlers", func() {
 
 				It("should fail", func() {
 					err := handler(responseRecorder, request)
+					Expect(err).NotTo(BeNil())
+				})
+			})
+		})
+	})
+
+	Describe("PUT /restaurant/posts/:date", func() {
+		var (
+			sessionManager        session.Manager
+			postsCollection       db.OfferGroupPosts
+			restaurantsCollection db.Restaurants
+			usersCollection       db.Users
+			handler               router.HandlerWithParams
+		)
+
+		JustBeforeEach(func() {
+			handler = PutOfferGroupPost(postsCollection, sessionManager, usersCollection, restaurantsCollection)
+		})
+
+		ExpectUserToBeLoggedIn(func() *router.HandlerError {
+			return handler(responseRecorder, request, nil)
+		}, func(mgr session.Manager, users db.Users) {
+			sessionManager = mgr
+			usersCollection = users
+		})
+
+		Context("with session set and a matching user in DB", func() {
+			var (
+				mockSessionManager        *mocks.Manager
+				mockPostsCollection       *mocks.OfferGroupPosts
+				mockRestaurantsCollection *mocks.Restaurants
+				mockUsersCollection       *mocks.Users
+				restaurantID              bson.ObjectId
+				id                        bson.ObjectId
+				params                    httprouter.Params
+			)
+
+			BeforeEach(func() {
+				mockSessionManager = new(mocks.Manager)
+				sessionManager = mockSessionManager
+				mockPostsCollection = new(mocks.OfferGroupPosts)
+				postsCollection = mockPostsCollection
+				mockRestaurantsCollection = new(mocks.Restaurants)
+				restaurantsCollection = mockRestaurantsCollection
+				mockUsersCollection = new(mocks.Users)
+				usersCollection = mockUsersCollection
+				id = bson.NewObjectId()
+
+				restaurantID = bson.NewObjectId()
+				restaurant := &model.Restaurant{
+					ID: restaurantID,
+				}
+				user := &model.User{
+					RestaurantIDs: []bson.ObjectId{restaurant.ID},
+				}
+
+				mockSessionManager.On("Get", mock.Anything).Return("session", nil)
+				mockUsersCollection.On("GetSessionID", "session").Return(user, nil)
+				mockRestaurantsCollection.On("GetID", restaurantID).Return(restaurant, nil)
+
+				requestMethod = "PUT"
+				params = httprouter.Params{httprouter.Param{
+					Key:   "date",
+					Value: "2015-04-10",
+				}}
+			})
+
+			AfterEach(func() {
+				mockSessionManager.AssertExpectations(GinkgoT())
+				mockPostsCollection.AssertExpectations(GinkgoT())
+				mockRestaurantsCollection.AssertExpectations(GinkgoT())
+				mockUsersCollection.AssertExpectations(GinkgoT())
+			})
+
+			Context("with valid input", func() {
+				BeforeEach(func() {
+					requestData = map[string]interface{}{
+						"_id":              id,
+						"date":             "2015-04-10",
+						"message_template": "a message template",
+					}
+				})
+
+				Context("with DB update succeeding", func() {
+					BeforeEach(func() {
+						mockPostsCollection.On("UpdateByID", id, &model.OfferGroupPost{
+							ID:              id,
+							Date:            "2015-04-10",
+							RestaurantID:    restaurantID,
+							MessageTemplate: "a message template",
+						}).Return(nil)
+					})
+
+					It("should succeed", func() {
+						err := handler(responseRecorder, request, params)
+						Expect(err).To(BeNil())
+					})
+
+					It("should return json", func() {
+						handler(responseRecorder, request, params)
+						contentTypes := responseRecorder.HeaderMap["Content-Type"]
+						Expect(contentTypes).To(HaveLen(1))
+						Expect(contentTypes[0]).To(Equal("application/json"))
+					})
+
+					It("should return the post", func() {
+						handler(responseRecorder, request, params)
+						var post *model.OfferGroupPost
+						json.Unmarshal(responseRecorder.Body.Bytes(), &post)
+						Expect(post.ID).To(Equal(id))
+					})
+				})
+
+				Context("with DB update failing", func() {
+					BeforeEach(func() {
+						mockPostsCollection.On("UpdateByID", id, mock.AnythingOfType("*model.OfferGroupPost")).Return(errors.New("things"))
+					})
+
+					It("should fail", func() {
+						err := handler(responseRecorder, request, params)
+						Expect(err).NotTo(BeNil())
+					})
+				})
+			})
+
+			Context("with a non-matching date", func() {
+				BeforeEach(func() {
+					requestData = map[string]interface{}{
+						"_id":  id,
+						"date": "2015-04-11",
+					}
+				})
+
+				It("should fail", func() {
+					err := handler(responseRecorder, request, params)
+					Expect(err).NotTo(BeNil())
+				})
+			})
+
+			Context("without an id", func() {
+				BeforeEach(func() {
+					requestData = map[string]interface{}{
+						"date": "2015-04-10",
+					}
+					mockPostsCollection.On("UpdateByID", bson.ObjectId(""), mock.AnythingOfType("*model.OfferGroupPost")).Return(errors.New("missing stuff"))
+				})
+
+				It("should fail", func() {
+					err := handler(responseRecorder, request, params)
 					Expect(err).NotTo(BeNil())
 				})
 			})

--- a/handler/offer_group_post_handler_test.go
+++ b/handler/offer_group_post_handler_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 var _ = Describe("OfferGroupPostHandlers", func() {
-	Describe("GET /restaurant/post/:date", func() {
+	Describe("GET /restaurant/posts/:date", func() {
 		var (
 			sessionManager        session.Manager
 			postsCollection       db.OfferGroupPosts

--- a/handler/offers_set_handler.go
+++ b/handler/offers_set_handler.go
@@ -2,9 +2,7 @@ package handler
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"strings"
 	"unicode"
 	"unicode/utf8"
 
@@ -155,7 +153,7 @@ func postOfferToFB(offer model.Offer, user *model.User, restaurant *model.Restau
 	if restaurant.FacebookPageID == "" {
 		return "", nil
 	}
-	message := formFBOfferMessage(offer)
+	message := formFBOfferMessage(&offer)
 	post, err := api.PagePublish(user.Session.FacebookPageToken, restaurant.FacebookPageID, message)
 	if err != nil {
 		return "", router.NewHandlerError(err, "Failed to post the offer to Facebook", http.StatusBadGateway)
@@ -163,11 +161,6 @@ func postOfferToFB(offer model.Offer, user *model.User, restaurant *model.Restau
 	return post.ID, nil
 }
 
-func formFBOfferMessage(o model.Offer) string {
-	ingredients := strings.Join(o.Ingredients, ", ")
-	capitalizedIngredients := capitalizeString(ingredients)
-	return fmt.Sprintf("%s - %s", o.Title, capitalizedIngredients)
-}
 
 func capitalizeString(s string) string {
 	if s == "" {

--- a/handler/offers_set_handler.go
+++ b/handler/offers_set_handler.go
@@ -184,6 +184,7 @@ func parseOffer(r *http.Request, restaurant *model.Restaurant) (*model.OfferPOST
 		return nil, err
 	}
 	offer.Restaurant = model.OfferRestaurant{
+		ID:       restaurant.ID,
 		Name:     restaurant.Name,
 		Region:   restaurant.Region,
 		Address:  restaurant.Address,

--- a/handler/offers_set_handler_test.go
+++ b/handler/offers_set_handler_test.go
@@ -90,31 +90,27 @@ var _ = Describe("OffersHandler", func() {
 					}
 				})
 
-				It("should fail", func(done Done) {
-					defer close(done)
+				It("should fail", func() {
 					err := handler(responseRecorder, request)
 					Expect(err.Code).To(Equal(http.StatusBadGateway))
 				})
 			})
 
-			It("should succeed", func(done Done) {
-				defer close(done)
+			It("should succeed", func() {
 				err := handler(responseRecorder, request)
 				Expect(err).To(BeNil())
 			})
 
-			It("should return json", func(done Done) {
-				defer close(done)
+			It("should return json", func() {
 				handler(responseRecorder, request)
 				contentTypes := responseRecorder.HeaderMap["Content-Type"]
 				Expect(contentTypes).To(HaveLen(1))
 				Expect(contentTypes[0]).To(Equal("application/json"))
 			})
 
-			It("should include the offer with the new ID", func(done Done) {
-				defer close(done)
+			It("should include the offer with the new ID", func() {
 				handler(responseRecorder, request)
-				var offer *model.OfferJSON
+				var offer model.OfferJSON
 				json.Unmarshal(responseRecorder.Body.Bytes(), &offer)
 				Expect(offer.ID).To(Equal(objectID))
 				Expect(offer.FBPostID).To(Equal("postid"))
@@ -417,7 +413,7 @@ func (m mockUsers) GetSessionID(session string) (*model.User, error) {
 	}
 	user := &model.User{
 		ID:            objectID,
-		RestaurantIDs: []bson.ObjectId{"restid"},
+		RestaurantIDs: []bson.ObjectId{"12letrrestid"},
 		Session: &model.UserSession{
 			FacebookUserToken: oauth2.Token{
 				AccessToken: "usertoken",
@@ -448,6 +444,7 @@ func (m mockOffers) Insert(offers ...*model.Offer) ([]*model.Offer, error) {
 	Expect(offer.Tags).To(ContainElement("tag1"))
 	Expect(offer.Tags).To(ContainElement("tag2"))
 	Expect(offer.Price).To(BeNumerically("~", 123.58))
+	Expect(offer.Restaurant.ID).To(Equal(bson.ObjectId("12letrrestid")))
 	Expect(offer.Restaurant.Name).To(Equal("Asian Chef"))
 	Expect(offer.Restaurant.Region).To(Equal("Tartu"))
 	Expect(offer.Restaurant.Address).To(Equal("an-address"))
@@ -473,6 +470,7 @@ func (m mockOffers) UpdateID(id bson.ObjectId, offer *model.Offer) error {
 	Expect(offer.Tags).To(ContainElement("tag1"))
 	Expect(offer.Tags).To(ContainElement("tag2"))
 	Expect(offer.Price).To(BeNumerically("~", 123.58))
+	Expect(offer.Restaurant.ID).To(Equal(bson.ObjectId("12letrrestid")))
 	Expect(offer.Restaurant.Name).To(Equal("Asian Chef"))
 	Expect(offer.Restaurant.Region).To(Equal("Tartu"))
 	Expect(offer.Restaurant.Address).To(Equal("an-address"))
@@ -505,8 +503,9 @@ func (m mockOffers) GetID(id bson.ObjectId) (*model.Offer, error) {
 }
 
 func (m mockRestaurants) GetID(id bson.ObjectId) (*model.Restaurant, error) {
-	Expect(id).To(Equal(bson.ObjectId("restid")))
+	Expect(id).To(Equal(bson.ObjectId("12letrrestid")))
 	restaurant := &model.Restaurant{
+		ID:             id,
 		FacebookPageID: "pageid",
 		Name:           "Asian Chef",
 		Region:         "Tartu",

--- a/handler/offers_set_handler_test.go
+++ b/handler/offers_set_handler_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/Lunchr/luncher-api/db"
 	"github.com/Lunchr/luncher-api/db/model"
 	. "github.com/Lunchr/luncher-api/handler"
+	"github.com/Lunchr/luncher-api/handler/mocks"
 	"github.com/Lunchr/luncher-api/router"
 	"github.com/Lunchr/luncher-api/session"
 	"github.com/Lunchr/luncher-api/storage"
 	"github.com/deiwin/facebook"
-	fbmodel "github.com/deiwin/facebook/model"
 	"github.com/julienschmidt/httprouter"
 	"golang.org/x/oauth2"
 	"gopkg.in/mgo.v2/bson"
@@ -40,6 +40,8 @@ var _ = Describe("OffersHandler", func() {
 			authenticator         facebook.Authenticator
 			sessionManager        session.Manager
 			imageStorage          storage.Images
+			regionsCollection     db.Regions
+			postsCollection       *mocks.OfferGroupPosts
 		)
 
 		BeforeEach(func() {
@@ -49,7 +51,8 @@ var _ = Describe("OffersHandler", func() {
 		})
 
 		JustBeforeEach(func() {
-			handler = PostOffers(offersCollection, usersCollection, restaurantsCollection, sessionManager, authenticator, imageStorage)
+			handler = PostOffers(offersCollection, usersCollection, restaurantsCollection, sessionManager, authenticator,
+				imageStorage, regionsCollection, postsCollection)
 		})
 
 		ExpectUserToBeLoggedIn(func() *router.HandlerError {
@@ -61,6 +64,9 @@ var _ = Describe("OffersHandler", func() {
 
 		Context("with session set and a matching user in DB", func() {
 			BeforeEach(func() {
+				postsCollection = new(mocks.OfferGroupPosts)
+				postsCollection.On("GetByDate", model.DateWithoutTime("2014-11-11"), bson.ObjectId("12letrrestid")).Return(&model.OfferGroupPost{}, nil)
+
 				sessionManager = &mockSessionManager{isSet: true, id: "correctSession"}
 				requestMethod = "POST"
 				requestData = map[string]interface{}{
@@ -80,22 +86,6 @@ var _ = Describe("OffersHandler", func() {
 				imageStorage = mockImageStorage{}
 			})
 
-			Context("with post to FB failing", func() {
-				BeforeEach(func() {
-					authenticator = &mockAuthenticator{
-						api: &mockAPI{
-							message:    "postmessage",
-							shouldFail: true,
-						},
-					}
-				})
-
-				It("should fail", func() {
-					err := handler(responseRecorder, request)
-					Expect(err.Code).To(Equal(http.StatusBadGateway))
-				})
-			})
-
 			It("should succeed", func() {
 				err := handler(responseRecorder, request)
 				Expect(err).To(BeNil())
@@ -113,7 +103,6 @@ var _ = Describe("OffersHandler", func() {
 				var offer model.OfferJSON
 				json.Unmarshal(responseRecorder.Body.Bytes(), &offer)
 				Expect(offer.ID).To(Equal(objectID))
-				Expect(offer.FBPostID).To(Equal("postid"))
 				Expect(offer.Image.Large).To(Equal("images/a large image path"))
 			})
 		})
@@ -127,6 +116,8 @@ var _ = Describe("OffersHandler", func() {
 			authenticator         facebook.Authenticator
 			sessionManager        session.Manager
 			imageStorage          storage.Images
+			regionsCollection     db.Regions
+			postsCollection       *mocks.OfferGroupPosts
 			params                httprouter.Params
 		)
 
@@ -138,10 +129,13 @@ var _ = Describe("OffersHandler", func() {
 				Key:   "id",
 				Value: objectID.Hex(),
 			}}
+			postsCollection = new(mocks.OfferGroupPosts)
+			postsCollection.On("GetByDate", model.DateWithoutTime("2014-11-11"), bson.ObjectId("12letrrestid")).Return(&model.OfferGroupPost{}, nil)
 		})
 
 		JustBeforeEach(func() {
-			handler = PutOffers(offersCollection, usersCollection, restaurantsCollection, sessionManager, authenticator, imageStorage)
+			handler = PutOffers(offersCollection, usersCollection, restaurantsCollection, sessionManager, authenticator,
+				imageStorage, regionsCollection, postsCollection)
 		})
 
 		ExpectUserToBeLoggedIn(func() *router.HandlerError {
@@ -197,9 +191,8 @@ var _ = Describe("OffersHandler", func() {
 				}
 				currentOffer := &model.Offer{
 					CommonOfferFields: model.CommonOfferFields{
-						ID:       objectID2,
-						Title:    "an offer title",
-						FBPostID: "fb post id",
+						ID:    objectID2,
+						Title: "an offer title",
 					},
 					ImageChecksum: "image checksum",
 				}
@@ -237,9 +230,8 @@ var _ = Describe("OffersHandler", func() {
 				}
 				currentOffer := &model.Offer{
 					CommonOfferFields: model.CommonOfferFields{
-						ID:       objectID,
-						Title:    "an offer title",
-						FBPostID: "fb post id",
+						ID:    objectID,
+						Title: "an offer title",
 					},
 					ImageChecksum: "image checksum",
 				}
@@ -252,23 +244,6 @@ var _ = Describe("OffersHandler", func() {
 					},
 				}
 				imageStorage = mockImageStorage{}
-			})
-
-			Context("with post to FB failing", func() {
-				BeforeEach(func() {
-					authenticator = &mockAuthenticator{
-						api: &mockAPI{
-							message:    "postmessage",
-							shouldFail: true,
-						},
-					}
-				})
-
-				It("should fail", func(done Done) {
-					defer close(done)
-					err := handler(responseRecorder, request, params)
-					Expect(err.Code).To(Equal(http.StatusBadGateway))
-				})
 			})
 
 			It("should succeed", func(done Done) {
@@ -291,7 +266,6 @@ var _ = Describe("OffersHandler", func() {
 				var offer *model.OfferJSON
 				json.Unmarshal(responseRecorder.Body.Bytes(), &offer)
 				Expect(offer.ID).To(Equal(objectID))
-				Expect(offer.FBPostID).To(Equal("postid"))
 				Expect(offer.Image.Large).To(Equal("images/a large image path"))
 			})
 		})
@@ -299,24 +273,31 @@ var _ = Describe("OffersHandler", func() {
 
 	Describe("DeleteOffers", func() {
 		var (
-			usersCollection db.Users
-			handler         router.HandlerWithParams
-			authenticator   facebook.Authenticator
-			sessionManager  session.Manager
-			params          httprouter.Params
+			usersCollection       db.Users
+			handler               router.HandlerWithParams
+			authenticator         facebook.Authenticator
+			sessionManager        session.Manager
+			restaurantsCollection db.Restaurants
+			regionsCollection     db.Regions
+			postsCollection       *mocks.OfferGroupPosts
+			params                httprouter.Params
 		)
 
 		BeforeEach(func() {
 			usersCollection = &mockUsers{}
+			restaurantsCollection = &mockRestaurants{}
 			authenticator = &mockAuthenticator{}
 			params = httprouter.Params{httprouter.Param{
 				Key:   "id",
 				Value: objectID.Hex(),
 			}}
+			postsCollection = new(mocks.OfferGroupPosts)
+			postsCollection.On("GetByDate", model.DateWithoutTime("2014-11-11"), bson.ObjectId("12letrrestid")).Return(&model.OfferGroupPost{}, nil)
 		})
 
 		JustBeforeEach(func() {
-			handler = DeleteOffers(offersCollection, usersCollection, sessionManager, authenticator)
+			handler = DeleteOffers(offersCollection, usersCollection, sessionManager, authenticator, restaurantsCollection,
+				regionsCollection, postsCollection)
 		})
 
 		ExpectUserToBeLoggedIn(func() *router.HandlerError {
@@ -362,7 +343,7 @@ var _ = Describe("OffersHandler", func() {
 					CommonOfferFields: model.CommonOfferFields{
 						ID:       objectID,
 						Title:    "an offer title",
-						FBPostID: "fb post id",
+						FromTime: time.Date(2014, 11, 11, 0, 0, 0, 0, time.UTC),
 					},
 					ImageChecksum: "image checksum",
 				}
@@ -372,23 +353,6 @@ var _ = Describe("OffersHandler", func() {
 				authenticator = &mockAuthenticator{
 					api: &mockAPI{},
 				}
-			})
-
-			Context("with post to FB failing", func() {
-				BeforeEach(func() {
-					authenticator = &mockAuthenticator{
-						api: &mockAPI{
-							message:    "postmessage",
-							shouldFail: true,
-						},
-					}
-				})
-
-				It("should fail", func(done Done) {
-					defer close(done)
-					err := handler(responseRecorder, request, params)
-					Expect(err.Code).To(Equal(http.StatusBadGateway))
-				})
 			})
 
 			It("should succeed", func(done Done) {
@@ -434,7 +398,6 @@ type mockOffers struct {
 func (m mockOffers) Insert(offers ...*model.Offer) ([]*model.Offer, error) {
 	Expect(offers).To(HaveLen(1))
 	offer := offers[0]
-	Expect(offer.FBPostID).To(Equal("postid"))
 	Expect(offer.Title).To(Equal("thetitle"))
 	Expect(offer.Ingredients).To(HaveLen(3))
 	Expect(offer.Ingredients).To(ContainElement("ingredient1"))
@@ -460,7 +423,6 @@ func (m mockOffers) Insert(offers ...*model.Offer) ([]*model.Offer, error) {
 }
 
 func (m mockOffers) UpdateID(id bson.ObjectId, offer *model.Offer) error {
-	Expect(offer.FBPostID).To(Equal("postid"))
 	Expect(offer.Title).To(Equal("thetitle"))
 	Expect(offer.Ingredients).To(HaveLen(3))
 	Expect(offer.Ingredients).To(ContainElement("ingredient1"))
@@ -505,11 +467,10 @@ func (m mockOffers) GetID(id bson.ObjectId) (*model.Offer, error) {
 func (m mockRestaurants) GetID(id bson.ObjectId) (*model.Restaurant, error) {
 	Expect(id).To(Equal(bson.ObjectId("12letrrestid")))
 	restaurant := &model.Restaurant{
-		ID:             id,
-		FacebookPageID: "pageid",
-		Name:           "Asian Chef",
-		Region:         "Tartu",
-		Address:        "an-address",
+		ID:      id,
+		Name:    "Asian Chef",
+		Region:  "Tartu",
+		Address: "an-address",
 		Location: model.Location{
 			Type:        "Point",
 			Coordinates: []float64{26.7, 58.4},
@@ -537,21 +498,6 @@ func (m mockAPI) PostDelete(pageAccessToken, postID string) error {
 	Expect(pageAccessToken).To(Equal("pagetoken"))
 	Expect(postID).To(Equal("fb post id"))
 	return nil
-}
-
-func (m mockAPI) PagePublish(pageAccessToken, pageID, message string) (*fbmodel.Post, error) {
-	if m.shouldFail {
-		return nil, errors.New("post to FB failed")
-	}
-
-	Expect(pageAccessToken).To(Equal("pagetoken"))
-	Expect(pageID).To(Equal("pageid"))
-	Expect(message).To(Equal(m.message))
-
-	post := &fbmodel.Post{
-		ID: "postid",
-	}
-	return post, nil
 }
 
 type mockRegions struct {

--- a/handler/restaurants_handler.go
+++ b/handler/restaurants_handler.go
@@ -62,7 +62,7 @@ func PostRestaurants(c db.Restaurants, sessionManager session.Manager, users db.
 // currently logged in user
 func RestaurantOffers(restaurants db.Restaurants, sessionManager session.Manager, users db.Users, offers db.Offers, imageStorage storage.Images) router.Handler {
 	handler := func(w http.ResponseWriter, r *http.Request, user *model.User, restaurant *model.Restaurant) *router.HandlerError {
-		offers, err := offers.GetForRestaurant(restaurant.Name, time.Now())
+		offers, err := offers.GetForRestaurant(restaurant.ID, time.Now())
 		if err != nil {
 			return router.NewHandlerError(err, "Failed to find upcoming offers for this restaurant", http.StatusInternalServerError)
 		}

--- a/handler/restaurants_handler.go
+++ b/handler/restaurants_handler.go
@@ -111,6 +111,10 @@ func parseRestaurant(r *http.Request) (*model.Restaurant, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Add default values for configurable fields
+	if restaurant.DefaultGroupPostMessageTemplate == "" {
+		restaurant.DefaultGroupPostMessageTemplate = "Tänased päevapakkumised on:"
+	}
 	// XXX please look away, this is a hack
 	if strings.Contains(strings.ToLower(restaurant.Address), "tartu") {
 		restaurant.Region = "Tartu"

--- a/handler/restaurants_handler.go
+++ b/handler/restaurants_handler.go
@@ -50,7 +50,7 @@ func PostRestaurants(c db.Restaurants, sessionManager session.Manager, users db.
 		user.RestaurantIDs = append(user.RestaurantIDs, insertedRestaurant.ID)
 		err = users.Update(user.FacebookUserID, user)
 		if err != nil {
-			// TODO: revert the restaurant insertion we just did?
+			// TODO: revert the restaurant insertion we just did? Look into mgo's txn package
 			return router.NewHandlerError(err, "Failed to store the restaurant in the DB", http.StatusInternalServerError)
 		}
 		return writeJSON(w, insertedRestaurant)

--- a/handler/restaurants_handler_test.go
+++ b/handler/restaurants_handler_test.go
@@ -386,8 +386,8 @@ func (mock mockRestaurants) Get() (restaurants []*model.Restaurant, err error) {
 	return
 }
 
-func (c mockOffers) GetForRestaurant(restaurant string, startTime time.Time) ([]*model.Offer, error) {
-	Expect(restaurant).To(Equal("Asian Chef"))
+func (c mockOffers) GetForRestaurant(restaurantID bson.ObjectId, startTime time.Time) ([]*model.Offer, error) {
+	Expect(restaurantID).To(Equal(bson.ObjectId("12letrrestid")))
 	Expect(startTime.Sub(time.Now())).To(BeNumerically("~", 0, time.Second))
 	return []*model.Offer{
 		&model.Offer{

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ func main() {
 	tagsCollection := db.NewTags(dbClient)
 	regionsCollection := db.NewRegions(dbClient)
 	restaurantsCollection := db.NewRestaurants(dbClient)
+	offerGroupPostsCollection := db.NewOfferGroupPosts(dbClient)
 
 	sessionManager := session.NewManager()
 	mainConfig, err := NewConfig()
@@ -59,6 +60,7 @@ func main() {
 	r.GET("/restaurant", handler.Restaurant(restaurantsCollection, sessionManager, usersCollection))
 	r.POST("/restaurants", handler.PostRestaurants(restaurantsCollection, sessionManager, usersCollection))
 	r.GET("/restaurant/offers", handler.RestaurantOffers(restaurantsCollection, sessionManager, usersCollection, offersCollection, imageStorage))
+	r.GETWithParams("/restaurant/post/:date", handler.OfferGroupPost(offerGroupPostsCollection, sessionManager, usersCollection, restaurantsCollection))
 	r.GET("/logout", handler.Logout(sessionManager, usersCollection))
 	r.GET("/login/facebook", handler.RedirectToFBForLogin(sessionManager, facebookLoginAuthenticator))
 	r.GET("/login/facebook/redirected", handler.RedirectedFromFBForLogin(sessionManager, facebookLoginAuthenticator, usersCollection, restaurantsCollection))

--- a/main.go
+++ b/main.go
@@ -61,8 +61,10 @@ func main() {
 	r.POST("/restaurants", handler.PostRestaurants(restaurantsCollection, sessionManager, usersCollection))
 	r.GET("/restaurant/offers", handler.RestaurantOffers(restaurantsCollection, sessionManager, usersCollection, offersCollection, imageStorage))
 	r.GETWithParams("/restaurant/posts/:date", handler.OfferGroupPost(offerGroupPostsCollection, sessionManager, usersCollection, restaurantsCollection))
-	r.POST("/restaurant/posts", handler.PostOfferGroupPost(offerGroupPostsCollection, sessionManager, usersCollection, restaurantsCollection))
-	r.PUT("/restaurant/posts/:date", handler.PutOfferGroupPost(offerGroupPostsCollection, sessionManager, usersCollection, restaurantsCollection))
+	r.POST("/restaurant/posts", handler.PostOfferGroupPost(offerGroupPostsCollection, sessionManager, usersCollection,
+		restaurantsCollection, offersCollection, regionsCollection, facebookLoginAuthenticator))
+	r.PUT("/restaurant/posts/:date", handler.PutOfferGroupPost(offerGroupPostsCollection, sessionManager, usersCollection,
+		restaurantsCollection, offersCollection, regionsCollection, facebookLoginAuthenticator))
 	r.GET("/logout", handler.Logout(sessionManager, usersCollection))
 	r.GET("/login/facebook", handler.RedirectToFBForLogin(sessionManager, facebookLoginAuthenticator))
 	r.GET("/login/facebook/redirected", handler.RedirectedFromFBForLogin(sessionManager, facebookLoginAuthenticator, usersCollection, restaurantsCollection))

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ func main() {
 	r.POST("/restaurants", handler.PostRestaurants(restaurantsCollection, sessionManager, usersCollection))
 	r.GET("/restaurant/offers", handler.RestaurantOffers(restaurantsCollection, sessionManager, usersCollection, offersCollection, imageStorage))
 	r.GETWithParams("/restaurant/posts/:date", handler.OfferGroupPost(offerGroupPostsCollection, sessionManager, usersCollection, restaurantsCollection))
+	r.POST("/restaurant/posts", handler.PostOfferGroupPost(offerGroupPostsCollection, sessionManager, usersCollection, restaurantsCollection))
 	r.GET("/logout", handler.Logout(sessionManager, usersCollection))
 	r.GET("/login/facebook", handler.RedirectToFBForLogin(sessionManager, facebookLoginAuthenticator))
 	r.GET("/login/facebook/redirected", handler.RedirectedFromFBForLogin(sessionManager, facebookLoginAuthenticator, usersCollection, restaurantsCollection))

--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ func main() {
 	r.GET("/restaurant/offers", handler.RestaurantOffers(restaurantsCollection, sessionManager, usersCollection, offersCollection, imageStorage))
 	r.GETWithParams("/restaurant/posts/:date", handler.OfferGroupPost(offerGroupPostsCollection, sessionManager, usersCollection, restaurantsCollection))
 	r.POST("/restaurant/posts", handler.PostOfferGroupPost(offerGroupPostsCollection, sessionManager, usersCollection, restaurantsCollection))
+	r.PUT("/restaurant/posts/:date", handler.PutOfferGroupPost(offerGroupPostsCollection, sessionManager, usersCollection, restaurantsCollection))
 	r.GET("/logout", handler.Logout(sessionManager, usersCollection))
 	r.GET("/login/facebook", handler.RedirectToFBForLogin(sessionManager, facebookLoginAuthenticator))
 	r.GET("/login/facebook/redirected", handler.RedirectedFromFBForLogin(sessionManager, facebookLoginAuthenticator, usersCollection, restaurantsCollection))

--- a/main.go
+++ b/main.go
@@ -53,9 +53,12 @@ func main() {
 	r.GET("/regions", handler.Regions(regionsCollection))
 	r.GETWithParams("/regions/:name/offers", handler.RegionOffers(offersCollection, regionsCollection, imageStorage))
 	r.GET("/offers", handler.ProximalOffers(offersCollection, imageStorage))
-	r.POST("/offers", handler.PostOffers(offersCollection, usersCollection, restaurantsCollection, sessionManager, facebookLoginAuthenticator, imageStorage))
-	r.PUT("/offers/:id", handler.PutOffers(offersCollection, usersCollection, restaurantsCollection, sessionManager, facebookLoginAuthenticator, imageStorage))
-	r.DELETE("/offers/:id", handler.DeleteOffers(offersCollection, usersCollection, sessionManager, facebookLoginAuthenticator))
+	r.POST("/offers", handler.PostOffers(offersCollection, usersCollection, restaurantsCollection, sessionManager,
+		facebookLoginAuthenticator, imageStorage, regionsCollection, offerGroupPostsCollection))
+	r.PUT("/offers/:id", handler.PutOffers(offersCollection, usersCollection, restaurantsCollection, sessionManager,
+		facebookLoginAuthenticator, imageStorage, regionsCollection, offerGroupPostsCollection))
+	r.DELETE("/offers/:id", handler.DeleteOffers(offersCollection, usersCollection, sessionManager, facebookLoginAuthenticator,
+		restaurantsCollection, regionsCollection, offerGroupPostsCollection))
 	r.GET("/tags", handler.Tags(tagsCollection))
 	r.GET("/restaurant", handler.Restaurant(restaurantsCollection, sessionManager, usersCollection))
 	r.POST("/restaurants", handler.PostRestaurants(restaurantsCollection, sessionManager, usersCollection))

--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func main() {
 	r.GET("/restaurant", handler.Restaurant(restaurantsCollection, sessionManager, usersCollection))
 	r.POST("/restaurants", handler.PostRestaurants(restaurantsCollection, sessionManager, usersCollection))
 	r.GET("/restaurant/offers", handler.RestaurantOffers(restaurantsCollection, sessionManager, usersCollection, offersCollection, imageStorage))
-	r.GETWithParams("/restaurant/post/:date", handler.OfferGroupPost(offerGroupPostsCollection, sessionManager, usersCollection, restaurantsCollection))
+	r.GETWithParams("/restaurant/posts/:date", handler.OfferGroupPost(offerGroupPostsCollection, sessionManager, usersCollection, restaurantsCollection))
 	r.GET("/logout", handler.Logout(sessionManager, usersCollection))
 	r.GET("/login/facebook", handler.RedirectToFBForLogin(sessionManager, facebookLoginAuthenticator))
 	r.GET("/login/facebook/redirected", handler.RedirectedFromFBForLogin(sessionManager, facebookLoginAuthenticator, usersCollection, restaurantsCollection))


### PR DESCRIPTION
This object will be used to group offers for FB posts. This way we don't spam the restaurants FB page  stream with a bunch of offers every day. Instead we group all the days offers and gather them into a single FB post.
- [x] Add an API endpoint for getting the message template for a certain date for a restaurant. This should probably return the default template if nothing's stored in the DB.
- [x] Add API endpoints for POSTing and updating the message templates.
- [x] Update the `/offers` endpoints to post the offers to FB in groups grouped by date.
- [x] Make updates to message templates also update the post in FB.
