### PR TITLE
Refactor fb posting

### DIFF
--- a/facebook/facebook_suite_test.go
+++ b/facebook/facebook_suite_test.go
@@ -1,0 +1,13 @@
+package facebook_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestFacebook(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Facebook Suite")
+}

--- a/facebook/mocks/API.go
+++ b/facebook/mocks/API.go
@@ -1,0 +1,61 @@
+package mocks
+
+import "github.com/stretchr/testify/mock"
+
+import "github.com/deiwin/facebook/model"
+
+type API struct {
+	mock.Mock
+}
+
+func (m *API) Me() (*model.User, error) {
+	ret := m.Called()
+
+	var r0 *model.User
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).(*model.User)
+	}
+	r1 := ret.Error(1)
+
+	return r0, r1
+}
+func (m *API) Accounts() (*model.Accounts, error) {
+	ret := m.Called()
+
+	var r0 *model.Accounts
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).(*model.Accounts)
+	}
+	r1 := ret.Error(1)
+
+	return r0, r1
+}
+func (m *API) Page(pageID string) (*model.Page, error) {
+	ret := m.Called(pageID)
+
+	var r0 *model.Page
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).(*model.Page)
+	}
+	r1 := ret.Error(1)
+
+	return r0, r1
+}
+func (m *API) PagePublish(pageAccessToken string, pageID string, message string) (*model.Post, error) {
+	ret := m.Called(pageAccessToken, pageID, message)
+
+	var r0 *model.Post
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).(*model.Post)
+	}
+	r1 := ret.Error(1)
+
+	return r0, r1
+}
+func (m *API) PostDelete(pageAccessToken string, postID string) error {
+	ret := m.Called(pageAccessToken, postID)
+
+	r0 := ret.Error(0)
+
+	return r0
+}

--- a/facebook/mocks/Authenticator.go
+++ b/facebook/mocks/Authenticator.go
@@ -1,0 +1,45 @@
+package mocks
+
+import "github.com/deiwin/facebook"
+import "github.com/stretchr/testify/mock"
+
+import "net/http"
+import "golang.org/x/oauth2"
+
+type Authenticator struct {
+	mock.Mock
+}
+
+func (m *Authenticator) AuthURL(state string) string {
+	ret := m.Called(state)
+
+	r0 := ret.Get(0).(string)
+
+	return r0
+}
+func (m *Authenticator) Token(state string, r *http.Request) (*oauth2.Token, error) {
+	ret := m.Called(state, r)
+
+	var r0 *oauth2.Token
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).(*oauth2.Token)
+	}
+	r1 := ret.Error(1)
+
+	return r0, r1
+}
+func (m *Authenticator) APIConnection(tok *oauth2.Token) facebook.API {
+	ret := m.Called(tok)
+
+	r0 := ret.Get(0).(facebook.API)
+
+	return r0
+}
+func (m *Authenticator) PageAccessToken(tok *oauth2.Token, pageID string) (string, error) {
+	ret := m.Called(tok, pageID)
+
+	r0 := ret.Get(0).(string)
+	r1 := ret.Error(1)
+
+	return r0, r1
+}

--- a/facebook/mocks/OfferGroupPosts.go
+++ b/facebook/mocks/OfferGroupPosts.go
@@ -1,0 +1,87 @@
+package mocks
+
+import "github.com/stretchr/testify/mock"
+
+import "github.com/Lunchr/luncher-api/db/model"
+
+import "gopkg.in/mgo.v2/bson"
+
+type OfferGroupPosts struct {
+	mock.Mock
+}
+
+func (_m *OfferGroupPosts) Insert(_a0 ...*model.OfferGroupPost) ([]*model.OfferGroupPost, error) {
+	ret := _m.Called(_a0)
+
+	var r0 []*model.OfferGroupPost
+	if rf, ok := ret.Get(0).(func(...*model.OfferGroupPost) []*model.OfferGroupPost); ok {
+		r0 = rf(_a0...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.OfferGroupPost)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(...*model.OfferGroupPost) error); ok {
+		r1 = rf(_a0...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *OfferGroupPosts) UpdateByID(_a0 bson.ObjectId, _a1 *model.OfferGroupPost) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(bson.ObjectId, *model.OfferGroupPost) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *OfferGroupPosts) GetByID(_a0 bson.ObjectId) (*model.OfferGroupPost, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *model.OfferGroupPost
+	if rf, ok := ret.Get(0).(func(bson.ObjectId) *model.OfferGroupPost); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.OfferGroupPost)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(bson.ObjectId) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *OfferGroupPosts) GetByDate(_a0 model.DateWithoutTime, _a1 bson.ObjectId) (*model.OfferGroupPost, error) {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 *model.OfferGroupPost
+	if rf, ok := ret.Get(0).(func(model.DateWithoutTime, bson.ObjectId) *model.OfferGroupPost); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.OfferGroupPost)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(model.DateWithoutTime, bson.ObjectId) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/facebook/mocks/Offers.go
+++ b/facebook/mocks/Offers.go
@@ -1,0 +1,164 @@
+package mocks
+
+import "github.com/stretchr/testify/mock"
+
+import "time"
+import "github.com/Lunchr/luncher-api/db/model"
+import "github.com/Lunchr/luncher-api/geo"
+
+import "gopkg.in/mgo.v2/bson"
+
+type Offers struct {
+	mock.Mock
+}
+
+func (_m *Offers) Insert(_a0 ...*model.Offer) ([]*model.Offer, error) {
+	ret := _m.Called(_a0)
+
+	var r0 []*model.Offer
+	if rf, ok := ret.Get(0).(func(...*model.Offer) []*model.Offer); ok {
+		r0 = rf(_a0...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.Offer)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(...*model.Offer) error); ok {
+		r1 = rf(_a0...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Offers) GetForRegion(region string, startTime time.Time, endTime time.Time) ([]*model.Offer, error) {
+	ret := _m.Called(region, startTime, endTime)
+
+	var r0 []*model.Offer
+	if rf, ok := ret.Get(0).(func(string, time.Time, time.Time) []*model.Offer); ok {
+		r0 = rf(region, startTime, endTime)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.Offer)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, time.Time, time.Time) error); ok {
+		r1 = rf(region, startTime, endTime)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Offers) GetNear(loc geo.Location, startTime time.Time, endTime time.Time) ([]*model.OfferWithDistance, error) {
+	ret := _m.Called(loc, startTime, endTime)
+
+	var r0 []*model.OfferWithDistance
+	if rf, ok := ret.Get(0).(func(geo.Location, time.Time, time.Time) []*model.OfferWithDistance); ok {
+		r0 = rf(loc, startTime, endTime)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.OfferWithDistance)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(geo.Location, time.Time, time.Time) error); ok {
+		r1 = rf(loc, startTime, endTime)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Offers) GetForRestaurant(restaurantID bson.ObjectId, startTime time.Time) ([]*model.Offer, error) {
+	ret := _m.Called(restaurantID, startTime)
+
+	var r0 []*model.Offer
+	if rf, ok := ret.Get(0).(func(bson.ObjectId, time.Time) []*model.Offer); ok {
+		r0 = rf(restaurantID, startTime)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.Offer)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(bson.ObjectId, time.Time) error); ok {
+		r1 = rf(restaurantID, startTime)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Offers) GetForRestaurantWithinTimeBounds(restaurantID bson.ObjectId, startTime time.Time, endTime time.Time) ([]*model.Offer, error) {
+	ret := _m.Called(restaurantID, startTime, endTime)
+
+	var r0 []*model.Offer
+	if rf, ok := ret.Get(0).(func(bson.ObjectId, time.Time, time.Time) []*model.Offer); ok {
+		r0 = rf(restaurantID, startTime, endTime)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.Offer)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(bson.ObjectId, time.Time, time.Time) error); ok {
+		r1 = rf(restaurantID, startTime, endTime)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Offers) UpdateID(_a0 bson.ObjectId, _a1 *model.Offer) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(bson.ObjectId, *model.Offer) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *Offers) GetID(_a0 bson.ObjectId) (*model.Offer, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *model.Offer
+	if rf, ok := ret.Get(0).(func(bson.ObjectId) *model.Offer); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.Offer)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(bson.ObjectId) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Offers) RemoveID(_a0 bson.ObjectId) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(bson.ObjectId) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/facebook/mocks/Regions.go
+++ b/facebook/mocks/Regions.go
@@ -1,0 +1,68 @@
+package mocks
+
+import "github.com/Lunchr/luncher-api/db"
+import "github.com/stretchr/testify/mock"
+
+import "github.com/Lunchr/luncher-api/db/model"
+
+type Regions struct {
+	mock.Mock
+}
+
+func (_m *Regions) Insert(_a0 ...*model.Region) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(...*model.Region) error); ok {
+		r0 = rf(_a0...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *Regions) GetName(_a0 string) (*model.Region, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *model.Region
+	if rf, ok := ret.Get(0).(func(string) *model.Region); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.Region)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Regions) GetAll() db.RegionIter {
+	ret := _m.Called()
+
+	var r0 db.RegionIter
+	if rf, ok := ret.Get(0).(func() db.RegionIter); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(db.RegionIter)
+	}
+
+	return r0
+}
+func (_m *Regions) UpdateName(_a0 string, _a1 *model.Region) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, *model.Region) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/facebook/post.go
+++ b/facebook/post.go
@@ -1,0 +1,120 @@
+package facebook
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"gopkg.in/mgo.v2"
+
+	"github.com/Lunchr/luncher-api/db"
+	"github.com/Lunchr/luncher-api/db/model"
+	"github.com/Lunchr/luncher-api/router"
+	"github.com/deiwin/facebook"
+)
+
+type Post interface {
+	UpdateForDate(model.DateWithoutTime, *model.User, *model.Restaurant) *router.HandlerError
+	Update(*model.OfferGroupPost, *model.User, *model.Restaurant) *router.HandlerError
+}
+
+func NewPost(groupPosts db.OfferGroupPosts, offers db.Offers, regions db.Regions, fbAuth facebook.Authenticator) Post {
+	return &facebookPost{
+		groupPosts: groupPosts,
+		offers:     offers,
+		regions:    regions,
+		fbAuth:     fbAuth,
+	}
+}
+
+type facebookPost struct {
+	groupPosts db.OfferGroupPosts
+	offers     db.Offers
+	regions    db.Regions
+	fbAuth     facebook.Authenticator
+}
+
+func (f *facebookPost) UpdateForDate(date model.DateWithoutTime, user *model.User, restaurant *model.Restaurant) *router.HandlerError {
+	post, err := f.groupPosts.GetByDate(date, restaurant.ID)
+	if err == mgo.ErrNotFound {
+		postToInsert := &model.OfferGroupPost{
+			RestaurantID:    restaurant.ID,
+			Date:            date,
+			MessageTemplate: restaurant.DefaultGroupPostMessageTemplate,
+		}
+		insertedPosts, err := f.groupPosts.Insert(postToInsert)
+		if err != nil {
+			router.NewHandlerError(err, "Failed to create a group post with restaurant defaults", http.StatusInternalServerError)
+		}
+		post = insertedPosts[0]
+	} else if err != nil {
+		return router.NewHandlerError(err, "Failed to fetch a group post for that date", http.StatusInternalServerError)
+	}
+	return f.Update(post, user, restaurant)
+}
+
+func (f *facebookPost) Update(post *model.OfferGroupPost, user *model.User, restaurant *model.Restaurant) *router.HandlerError {
+	if restaurant.FacebookPageID == "" {
+		return nil
+	}
+	fbAPI := f.fbAuth.APIConnection(&user.Session.FacebookUserToken)
+	// Remove the current post from FB, if it's already there
+	if post.FBPostID != "" {
+		err := fbAPI.PostDelete(user.Session.FacebookPageToken, post.FBPostID)
+		if err != nil {
+			return router.NewHandlerError(err, "Failed to delete the current post from Facebook", http.StatusBadGateway)
+		}
+	}
+	offersForDate, handlerErr := f.getOffersForDate(post.Date, restaurant)
+	if handlerErr != nil {
+		return handlerErr
+	} else if len(offersForDate) == 0 {
+		return nil
+	}
+	message := f.formFBMessage(post, offersForDate)
+	// Add the new version
+	fbPost, err := fbAPI.PagePublish(user.Session.FacebookPageToken, restaurant.FacebookPageID, message)
+	if err != nil {
+		return router.NewHandlerError(err, "Failed to post the offer to Facebook", http.StatusBadGateway)
+	}
+	post.FBPostID = fbPost.ID
+	if err = f.groupPosts.UpdateByID(post.ID, post); err != nil {
+		return router.NewHandlerError(err, "Failed to update a group post in the DB", http.StatusInternalServerError)
+	}
+	return nil
+}
+
+func (f *facebookPost) formFBMessage(post *model.OfferGroupPost, offers []*model.Offer) string {
+	offerMessages := make([]string, len(offers))
+	for i, offer := range offers {
+		offerMessages[i] = f.formFBOfferMessage(offer)
+	}
+	offersMessage := strings.Join(offerMessages, "\n")
+	return fmt.Sprintf("%s\n\n%s", post.MessageTemplate, offersMessage)
+}
+
+func (f *facebookPost) formFBOfferMessage(o *model.Offer) string {
+	// TODO get rid of the hard-coded €
+	return fmt.Sprintf("%s - %.2f€", o.Title, o.Price)
+}
+
+func (f *facebookPost) getOffersForDate(date model.DateWithoutTime, restaurant *model.Restaurant) ([]*model.Offer, *router.HandlerError) {
+	region, err := f.regions.GetName(restaurant.Region)
+	if err != nil {
+		return nil, router.NewHandlerError(err, "Failed to find the restaurant's region", http.StatusInternalServerError)
+	}
+	location, err := time.LoadLocation(region.Location)
+	if err != nil {
+		return nil, router.NewHandlerError(err, "Failed to load region's location", http.StatusInternalServerError)
+	}
+	startTime, endTime, err := date.TimeBounds(location)
+	if err != nil {
+		return nil, router.NewHandlerError(err, "Failed to parse a date", http.StatusInternalServerError)
+	}
+	offersForDate, err := f.offers.GetForRestaurantWithinTimeBounds(restaurant.ID, startTime, endTime)
+	if err != nil {
+		return nil, router.NewHandlerError(err, "Failed to find offers for this date", http.StatusInternalServerError)
+	}
+	return offersForDate, nil
+}

--- a/facebook/post.go
+++ b/facebook/post.go
@@ -47,7 +47,7 @@ func (f *facebookPost) Update(date model.DateWithoutTime, user *model.User, rest
 		}
 		insertedPosts, err := f.groupPosts.Insert(postToInsert)
 		if err != nil {
-			router.NewHandlerError(err, "Failed to create a group post with restaurant defaults", http.StatusInternalServerError)
+			return router.NewHandlerError(err, "Failed to create a group post with restaurant defaults", http.StatusInternalServerError)
 		}
 		post = insertedPosts[0]
 	} else if err != nil {

--- a/facebook/post_test.go
+++ b/facebook/post_test.go
@@ -1,0 +1,50 @@
+package facebook_test
+
+import (
+	"github.com/Lunchr/luncher-api/db/model"
+	"github.com/Lunchr/luncher-api/facebook"
+	"github.com/Lunchr/luncher-api/facebook/mocks"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Post", func() {
+	var (
+		facebookPost facebook.Post
+
+		groupPosts *mocks.OfferGroupPosts
+		offers     *mocks.Offers
+		regions    *mocks.Regions
+		fbAuth     *mocks.Authenticator
+
+		user       *model.User
+		restaurant *model.Restaurant
+	)
+
+	BeforeEach(func() {
+		groupPosts = new(mocks.OfferGroupPosts)
+		offers = new(mocks.Offers)
+		regions = new(mocks.Regions)
+		fbAuth = new(mocks.Authenticator)
+
+		facebookPost = facebook.NewPost(groupPosts, offers, regions, fbAuth)
+	})
+
+	Describe("Update", func() {
+		var post *model.OfferGroupPost
+
+		Context("for restaurants without an associated FB page", func() {
+			BeforeEach(func() {
+				restaurant = &model.Restaurant{
+					FacebookPageID: "",
+				}
+			})
+
+			It("does nothing", func() {
+				err := facebookPost.Update(post, user, restaurant)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+})

--- a/facebook/post_test.go
+++ b/facebook/post_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Post", func() {
 	})
 
 	Describe("Update", func() {
-		var post *model.OfferGroupPost
+		var date model.DateWithoutTime
 
 		Context("for restaurants without an associated FB page", func() {
 			BeforeEach(func() {
@@ -42,7 +42,7 @@ var _ = Describe("Post", func() {
 			})
 
 			It("does nothing", func() {
-				err := facebookPost.Update(post, user, restaurant)
+				err := facebookPost.Update(date, user, restaurant)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})

--- a/facebook/post_test.go
+++ b/facebook/post_test.go
@@ -1,9 +1,14 @@
 package facebook_test
 
 import (
+	"time"
+
 	"github.com/Lunchr/luncher-api/db/model"
 	"github.com/Lunchr/luncher-api/facebook"
 	"github.com/Lunchr/luncher-api/facebook/mocks"
+	fbmodel "github.com/deiwin/facebook/model"
+	"golang.org/x/oauth2"
+	"gopkg.in/mgo.v2/bson"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -13,10 +18,10 @@ var _ = Describe("Post", func() {
 	var (
 		facebookPost facebook.Post
 
-		groupPosts *mocks.OfferGroupPosts
-		offers     *mocks.Offers
-		regions    *mocks.Regions
-		fbAuth     *mocks.Authenticator
+		groupPosts       *mocks.OfferGroupPosts
+		offersCollection *mocks.Offers
+		regions          *mocks.Regions
+		fbAuth           *mocks.Authenticator
 
 		user       *model.User
 		restaurant *model.Restaurant
@@ -24,11 +29,14 @@ var _ = Describe("Post", func() {
 
 	BeforeEach(func() {
 		groupPosts = new(mocks.OfferGroupPosts)
-		offers = new(mocks.Offers)
+		offersCollection = new(mocks.Offers)
 		regions = new(mocks.Regions)
 		fbAuth = new(mocks.Authenticator)
 
-		facebookPost = facebook.NewPost(groupPosts, offers, regions, fbAuth)
+		facebookPost = facebook.NewPost(groupPosts, offersCollection, regions, fbAuth)
+	})
+
+	JustBeforeEach(func() {
 	})
 
 	Describe("Update", func() {
@@ -39,11 +47,115 @@ var _ = Describe("Post", func() {
 				restaurant = &model.Restaurant{
 					FacebookPageID: "",
 				}
+				date = model.DateWithoutTime("2011-04-24")
 			})
 
 			It("does nothing", func() {
 				err := facebookPost.Update(date, user, restaurant)
 				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("for a restaurant with an associated FB page", func() {
+			var (
+				restaurantID      bson.ObjectId
+				facebookPageID    string
+				facebookUserToken *oauth2.Token
+				facebookPageToken string
+				fbAPI             *mocks.API
+			)
+
+			BeforeEach(func() {
+				restaurantID = bson.NewObjectId()
+				facebookPageID = "a page ID"
+				facebookUserToken = &oauth2.Token{
+					AccessToken: "a user token",
+				}
+				facebookPageToken = "a page token"
+
+				regionName := "a region"
+				region := &model.Region{
+					Name:     regionName,
+					Location: "UTC",
+				}
+				regions.On("GetName", regionName).Return(region, nil)
+
+				startTime := time.Date(2011, 04, 24, 0, 0, 0, 0, time.UTC)
+				endTime := time.Date(2011, 04, 25, 0, 0, 0, 0, time.UTC)
+				offers := []*model.Offer{
+					&model.Offer{
+						CommonOfferFields: model.CommonOfferFields{
+							Title: "atitle",
+							Price: 5.670000000000,
+						},
+					},
+					&model.Offer{
+						CommonOfferFields: model.CommonOfferFields{
+							Title: "btitle",
+							Price: 4.670000000000,
+						},
+					},
+				}
+				offersCollection.On("GetForRestaurantWithinTimeBounds", restaurantID, startTime, endTime).Return(offers, nil)
+
+				restaurant = &model.Restaurant{
+					ID:             restaurantID,
+					FacebookPageID: facebookPageID,
+					Region:         regionName,
+				}
+				user = &model.User{
+					Session: &model.UserSession{
+						FacebookUserToken: *facebookUserToken,
+						FacebookPageToken: facebookPageToken,
+					},
+				}
+				fbAPI = new(mocks.API)
+				fbAuth.On("APIConnection", facebookUserToken).Return(fbAPI)
+			})
+
+			Context("with an existing OfferGroupPost", func() {
+				var (
+					messageTemplate string
+					offerGroupPost  *model.OfferGroupPost
+					facebookPostID  string
+				)
+
+				BeforeEach(func() {
+					id := bson.NewObjectId()
+					messageTemplate = "a message template"
+					offerGroupPost = &model.OfferGroupPost{
+						ID:              id,
+						Date:            date,
+						MessageTemplate: messageTemplate,
+					}
+					groupPosts.On("GetByDate", date, restaurantID).Return(offerGroupPost, nil)
+
+					facebookPostID = "fb post id"
+					fbAPI.On("PagePublish", facebookPageToken, facebookPageID,
+						messageTemplate+"\n\natitle - 5.67€\nbtitle - 4.67€").Return(&fbmodel.Post{
+						ID: facebookPostID,
+					}, nil)
+					groupPosts.On("UpdateByID", id, &model.OfferGroupPost{
+						ID:              id,
+						Date:            date,
+						MessageTemplate: messageTemplate,
+						FBPostID:        facebookPostID,
+					}).Return(nil)
+				})
+
+				Context("without a previous associated FB post", func() {
+					AfterEach(func() {
+						groupPosts.AssertExpectations(GinkgoT())
+						offersCollection.AssertExpectations(GinkgoT())
+						regions.AssertExpectations(GinkgoT())
+						fbAuth.AssertExpectations(GinkgoT())
+					})
+
+					It("should succeed", func() {
+						err := facebookPost.Update(date, user, restaurant)
+						Expect(err).To(BeNil())
+					})
+				})
 			})
 		})
 	})

--- a/handler/mocks/Post.go
+++ b/handler/mocks/Post.go
@@ -1,0 +1,25 @@
+package mocks
+
+import "github.com/stretchr/testify/mock"
+
+import "github.com/Lunchr/luncher-api/db/model"
+import "github.com/Lunchr/luncher-api/router"
+
+type Post struct {
+	mock.Mock
+}
+
+func (_m *Post) Update(_a0 model.DateWithoutTime, _a1 *model.User, _a2 *model.Restaurant) *router.HandlerError {
+	ret := _m.Called(_a0, _a1, _a2)
+
+	var r0 *router.HandlerError
+	if rf, ok := ret.Get(0).(func(model.DateWithoutTime, *model.User, *model.Restaurant) *router.HandlerError); ok {
+		r0 = rf(_a0, _a1, _a2)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*router.HandlerError)
+		}
+	}
+
+	return r0
+}

--- a/handler/offer_group_post_handler_test.go
+++ b/handler/offer_group_post_handler_test.go
@@ -3,9 +3,6 @@ package handler_test
 import (
 	"encoding/json"
 	"errors"
-	"time"
-
-	"golang.org/x/oauth2"
 
 	"github.com/Lunchr/luncher-api/db"
 	"github.com/Lunchr/luncher-api/db/model"
@@ -13,8 +10,6 @@ import (
 	"github.com/Lunchr/luncher-api/handler/mocks"
 	"github.com/Lunchr/luncher-api/router"
 	"github.com/Lunchr/luncher-api/session"
-	"github.com/deiwin/facebook"
-	fbmodel "github.com/deiwin/facebook/model"
 	"github.com/julienschmidt/httprouter"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -149,16 +144,13 @@ var _ = Describe("OfferGroupPostHandlers", func() {
 			sessionManager        session.Manager
 			postsCollection       db.OfferGroupPosts
 			restaurantsCollection db.Restaurants
-			offersCollection      db.Offers
-			regionsCollection     db.Regions
-			fbAuth                facebook.Authenticator
 			usersCollection       db.Users
+			facebookPost          *mocks.Post
 			handler               router.Handler
 		)
 
 		JustBeforeEach(func() {
-			handler = PostOfferGroupPost(postsCollection, sessionManager, usersCollection, restaurantsCollection,
-				offersCollection, regionsCollection, fbAuth)
+			handler = PostOfferGroupPost(postsCollection, sessionManager, usersCollection, restaurantsCollection, facebookPost)
 		})
 
 		ExpectUserToBeLoggedIn(func() *router.HandlerError {
@@ -174,11 +166,10 @@ var _ = Describe("OfferGroupPostHandlers", func() {
 				mockPostsCollection       *mocks.OfferGroupPosts
 				mockRestaurantsCollection *mocks.Restaurants
 				mockUsersCollection       *mocks.Users
-				mockOffersCollection      *mocks.Offers
-				mockRegionsCollection     *mocks.Regions
-				mockFBAuth                *mocks.Authenticator
 				restaurantID              bson.ObjectId
 				id                        bson.ObjectId
+				user                      *model.User
+				restaurant                *model.Restaurant
 			)
 
 			BeforeEach(func() {
@@ -190,20 +181,15 @@ var _ = Describe("OfferGroupPostHandlers", func() {
 				restaurantsCollection = mockRestaurantsCollection
 				mockUsersCollection = new(mocks.Users)
 				usersCollection = mockUsersCollection
-				mockOffersCollection = new(mocks.Offers)
-				offersCollection = mockOffersCollection
-				mockRegionsCollection = new(mocks.Regions)
-				regionsCollection = mockRegionsCollection
-				mockFBAuth = new(mocks.Authenticator)
-				fbAuth = mockFBAuth
+				facebookPost = new(mocks.Post)
 
 				id = bson.NewObjectId()
 
 				restaurantID = bson.NewObjectId()
-				restaurant := &model.Restaurant{
+				restaurant = &model.Restaurant{
 					ID: restaurantID,
 				}
-				user := &model.User{
+				user = &model.User{
 					RestaurantIDs: []bson.ObjectId{restaurant.ID},
 				}
 
@@ -219,6 +205,7 @@ var _ = Describe("OfferGroupPostHandlers", func() {
 				mockPostsCollection.AssertExpectations(GinkgoT())
 				mockRestaurantsCollection.AssertExpectations(GinkgoT())
 				mockUsersCollection.AssertExpectations(GinkgoT())
+				facebookPost.AssertExpectations(GinkgoT())
 			})
 
 			Context("with valid input", func() {
@@ -229,93 +216,71 @@ var _ = Describe("OfferGroupPostHandlers", func() {
 				})
 
 				Context("with DB update succeeding", func() {
+					var date model.DateWithoutTime
 					BeforeEach(func() {
+						date = model.DateWithoutTime("2115-04-18")
 						mockPostsCollection.On("Insert", mock.AnythingOfType("[]*model.OfferGroupPost")).Return([]*model.OfferGroupPost{
 							&model.OfferGroupPost{
 								ID:              id,
-								Date:            model.DateWithoutTime("2115-04-18"),
+								Date:            date,
 								MessageTemplate: "messagetemplate",
 							},
 						}, nil)
 					})
 
-					It("should succeed", func() {
-						err := handler(responseRecorder, request)
-						Expect(err).To(BeNil())
+					Context("with FB update succeeding", func() {
+						BeforeEach(func() {
+							facebookPost.On("Update", date, user, restaurant).Return(nil)
+						})
+
+						It("should succeed", func() {
+							err := handler(responseRecorder, request)
+							Expect(err).To(BeNil())
+						})
+
+						It("should return json", func() {
+							handler(responseRecorder, request)
+							contentTypes := responseRecorder.HeaderMap["Content-Type"]
+							Expect(contentTypes).To(HaveLen(1))
+							Expect(contentTypes[0]).To(Equal("application/json"))
+						})
+
+						It("should include the post with the new ID", func() {
+							handler(responseRecorder, request)
+							var post model.OfferGroupPost
+							json.Unmarshal(responseRecorder.Body.Bytes(), &post)
+							Expect(post.ID).To(Equal(id))
+						})
 					})
 
-					It("should return json", func() {
-						handler(responseRecorder, request)
-						contentTypes := responseRecorder.HeaderMap["Content-Type"]
-						Expect(contentTypes).To(HaveLen(1))
-						Expect(contentTypes[0]).To(Equal("application/json"))
-					})
+					Context("with FB update failing", func() {
+						var err *router.HandlerError
+						BeforeEach(func() {
+							err = &router.HandlerError{Message: "a message"}
+							facebookPost.On("Update", date, user, restaurant).Return(err)
+						})
 
-					It("should include the post with the new ID", func() {
-						handler(responseRecorder, request)
-						var post model.OfferGroupPost
-						json.Unmarshal(responseRecorder.Body.Bytes(), &post)
-						Expect(post.ID).To(Equal(id))
+						It("should fail", func() {
+							handlerErr := handler(responseRecorder, request)
+							Expect(handlerErr).To(Equal(err))
+						})
 					})
 
 					Context("with a restaurant with an associated FB page", func() {
-						var fbPostID string
-
 						BeforeEach(func() {
 							fbPageID := "fbpageid"
-							regionName := "regionname"
 							restaurant := &model.Restaurant{
 								ID:             restaurantID,
 								FacebookPageID: fbPageID,
-								Region:         regionName,
 							}
-							fbUserToken := &oauth2.Token{}
-							fbPageToken := "afbpagetoken"
 							user := &model.User{
 								RestaurantIDs: []bson.ObjectId{restaurant.ID},
-								Session: &model.UserSession{
-									FacebookUserToken: *fbUserToken,
-									FacebookPageToken: fbPageToken,
-								},
 							}
 							mockRestaurantsCollection.GetID(restaurantID) // Best way I could think of getting rid of the previous mock
 							mockRestaurantsCollection.On("GetID", restaurantID).Return(restaurant, nil)
 							mockUsersCollection.GetSessionID("session")
 							mockUsersCollection.On("GetSessionID", "session").Return(user, nil)
-							fbAPI := new(mocks.API)
-							mockFBAuth.On("APIConnection", fbUserToken).Return(fbAPI)
-							region := &model.Region{
-								Location: "UTC",
-							}
-							mockRegionsCollection.On("GetName", regionName).Return(region, nil)
-
-							startTime := time.Date(2115, 04, 18, 0, 0, 0, 0, time.UTC)
-							endTime := time.Date(2115, 04, 19, 0, 0, 0, 0, time.UTC)
-							offers := []*model.Offer{
-								&model.Offer{
-									CommonOfferFields: model.CommonOfferFields{
-										Title: "atitle",
-										Price: 5.670000000000,
-									},
-								},
-								&model.Offer{
-									CommonOfferFields: model.CommonOfferFields{
-										Title: "btitle",
-										Price: 4.670000000000,
-									},
-								},
-							}
-							mockOffersCollection.On("GetForRestaurantWithinTimeBounds", restaurantID, startTime, endTime).Return(offers, nil)
-							fbPostID = "fbpostid"
-							fbAPI.On("PagePublish", fbPageToken, fbPageID, "messagetemplate\n\natitle - 5.67€\nbtitle - 4.67€").Return(&fbmodel.Post{
-								ID: fbPostID,
-							}, nil)
-							mockPostsCollection.On("UpdateByID", id, &model.OfferGroupPost{
-								ID:              id,
-								Date:            model.DateWithoutTime("2115-04-18"),
-								MessageTemplate: "messagetemplate",
-								FBPostID:        fbPostID,
-							}).Return(nil)
+							facebookPost.On("Update", model.DateWithoutTime("2115-04-18"), user, restaurant).Return(nil)
 						})
 
 						It("should succeed", func() {
@@ -358,15 +323,13 @@ var _ = Describe("OfferGroupPostHandlers", func() {
 			postsCollection       db.OfferGroupPosts
 			restaurantsCollection db.Restaurants
 			usersCollection       db.Users
-			offersCollection      db.Offers
-			regionsCollection     db.Regions
-			fbAuth                facebook.Authenticator
+			facebookPost          *mocks.Post
 			handler               router.HandlerWithParams
 		)
 
 		JustBeforeEach(func() {
 			handler = PutOfferGroupPost(postsCollection, sessionManager, usersCollection, restaurantsCollection,
-				offersCollection, regionsCollection, fbAuth)
+				facebookPost)
 		})
 
 		ExpectUserToBeLoggedIn(func() *router.HandlerError {
@@ -385,6 +348,8 @@ var _ = Describe("OfferGroupPostHandlers", func() {
 				restaurantID              bson.ObjectId
 				id                        bson.ObjectId
 				params                    httprouter.Params
+				user                      *model.User
+				restaurant                *model.Restaurant
 			)
 
 			BeforeEach(func() {
@@ -396,13 +361,15 @@ var _ = Describe("OfferGroupPostHandlers", func() {
 				restaurantsCollection = mockRestaurantsCollection
 				mockUsersCollection = new(mocks.Users)
 				usersCollection = mockUsersCollection
+				facebookPost = new(mocks.Post)
+
 				id = bson.NewObjectId()
 
 				restaurantID = bson.NewObjectId()
-				restaurant := &model.Restaurant{
+				restaurant = &model.Restaurant{
 					ID: restaurantID,
 				}
-				user := &model.User{
+				user = &model.User{
 					RestaurantIDs: []bson.ObjectId{restaurant.ID},
 				}
 
@@ -422,6 +389,7 @@ var _ = Describe("OfferGroupPostHandlers", func() {
 				mockPostsCollection.AssertExpectations(GinkgoT())
 				mockRestaurantsCollection.AssertExpectations(GinkgoT())
 				mockUsersCollection.AssertExpectations(GinkgoT())
+				facebookPost.AssertExpectations(GinkgoT())
 			})
 
 			Context("with valid input", func() {
@@ -434,13 +402,9 @@ var _ = Describe("OfferGroupPostHandlers", func() {
 				})
 
 				Context("with DB update succeeding", func() {
+					var date model.DateWithoutTime
 					BeforeEach(func() {
-						date := model.DateWithoutTime("2015-04-10")
-						mockPostsCollection.On("GetByDate", date, restaurantID).Return(&model.OfferGroupPost{
-							ID:              id,
-							Date:            date,
-							MessageTemplate: "messagetemplate",
-						}, nil)
+						date = model.DateWithoutTime("2015-04-10")
 
 						mockPostsCollection.On("UpdateByID", id, &model.OfferGroupPost{
 							ID:              id,
@@ -450,23 +414,42 @@ var _ = Describe("OfferGroupPostHandlers", func() {
 						}).Return(nil)
 					})
 
-					It("should succeed", func() {
-						err := handler(responseRecorder, request, params)
-						Expect(err).To(BeNil())
+					Context("with FB update succeeding", func() {
+						BeforeEach(func() {
+							facebookPost.On("Update", date, user, restaurant).Return(nil)
+						})
+
+						It("should succeed", func() {
+							err := handler(responseRecorder, request, params)
+							Expect(err).To(BeNil())
+						})
+
+						It("should return json", func() {
+							handler(responseRecorder, request, params)
+							contentTypes := responseRecorder.HeaderMap["Content-Type"]
+							Expect(contentTypes).To(HaveLen(1))
+							Expect(contentTypes[0]).To(Equal("application/json"))
+						})
+
+						It("should return the post", func() {
+							handler(responseRecorder, request, params)
+							var post *model.OfferGroupPost
+							json.Unmarshal(responseRecorder.Body.Bytes(), &post)
+							Expect(post.ID).To(Equal(id))
+						})
 					})
 
-					It("should return json", func() {
-						handler(responseRecorder, request, params)
-						contentTypes := responseRecorder.HeaderMap["Content-Type"]
-						Expect(contentTypes).To(HaveLen(1))
-						Expect(contentTypes[0]).To(Equal("application/json"))
-					})
+					Context("with FB update failing", func() {
+						var err *router.HandlerError
+						BeforeEach(func() {
+							err = &router.HandlerError{Message: "a message"}
+							facebookPost.On("Update", date, user, restaurant).Return(err)
+						})
 
-					It("should return the post", func() {
-						handler(responseRecorder, request, params)
-						var post *model.OfferGroupPost
-						json.Unmarshal(responseRecorder.Body.Bytes(), &post)
-						Expect(post.ID).To(Equal(id))
+						It("should fail", func() {
+							handlerErr := handler(responseRecorder, request, params)
+							Expect(handlerErr).To(Equal(err))
+						})
 					})
 				})
 

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/Lunchr/luncher-api/db"
+	luncherFacebook "github.com/Lunchr/luncher-api/facebook"
 	"github.com/Lunchr/luncher-api/handler"
 	"github.com/Lunchr/luncher-api/router"
 	"github.com/Lunchr/luncher-api/session"
@@ -51,6 +52,8 @@ func main() {
 	facebookRegistrationConfig := facebook.NewConfig(registrationRedirectURL, scopes)
 	facebookRegistrationAuthenticator := facebook.NewAuthenticator(facebookRegistrationConfig)
 
+	facebookPost := luncherFacebook.NewPost(offerGroupPostsCollection, offersCollection, regionsCollection, facebookLoginAuthenticator)
+
 	imageStorage := storage.NewImages()
 
 	r := router.NewWithPrefix("/api/v1/")
@@ -58,20 +61,20 @@ func main() {
 	r.GETWithParams("/regions/:name/offers", handler.RegionOffers(offersCollection, regionsCollection, imageStorage))
 	r.GET("/offers", handler.ProximalOffers(offersCollection, imageStorage))
 	r.POST("/offers", handler.PostOffers(offersCollection, usersCollection, restaurantsCollection, sessionManager,
-		facebookLoginAuthenticator, imageStorage, regionsCollection, offerGroupPostsCollection))
+		imageStorage, facebookPost))
 	r.PUT("/offers/:id", handler.PutOffers(offersCollection, usersCollection, restaurantsCollection, sessionManager,
-		facebookLoginAuthenticator, imageStorage, regionsCollection, offerGroupPostsCollection))
-	r.DELETE("/offers/:id", handler.DeleteOffers(offersCollection, usersCollection, sessionManager, facebookLoginAuthenticator,
-		restaurantsCollection, regionsCollection, offerGroupPostsCollection))
+		imageStorage, facebookPost))
+	r.DELETE("/offers/:id", handler.DeleteOffers(offersCollection, usersCollection, sessionManager, restaurantsCollection,
+		facebookPost))
 	r.GET("/tags", handler.Tags(tagsCollection))
 	r.GET("/restaurant", handler.Restaurant(restaurantsCollection, sessionManager, usersCollection))
 	r.POST("/restaurants", handler.PostRestaurants(restaurantsCollection, sessionManager, usersCollection))
 	r.GET("/restaurant/offers", handler.RestaurantOffers(restaurantsCollection, sessionManager, usersCollection, offersCollection, imageStorage))
 	r.GETWithParams("/restaurant/posts/:date", handler.OfferGroupPost(offerGroupPostsCollection, sessionManager, usersCollection, restaurantsCollection))
 	r.POST("/restaurant/posts", handler.PostOfferGroupPost(offerGroupPostsCollection, sessionManager, usersCollection,
-		restaurantsCollection, offersCollection, regionsCollection, facebookLoginAuthenticator))
+		restaurantsCollection, facebookPost))
 	r.PUT("/restaurant/posts/:date", handler.PutOfferGroupPost(offerGroupPostsCollection, sessionManager, usersCollection,
-		restaurantsCollection, offersCollection, regionsCollection, facebookLoginAuthenticator))
+		restaurantsCollection, facebookPost))
 	r.GET("/logout", handler.Logout(sessionManager, usersCollection))
 	r.GET("/login/facebook", handler.RedirectToFBForLogin(sessionManager, facebookLoginAuthenticator))
 	r.GET("/login/facebook/redirected", handler.RedirectedFromFBForLogin(sessionManager, facebookLoginAuthenticator, usersCollection, restaurantsCollection))


### PR DESCRIPTION
This simplifies the handlers by extracting the facebook post logic into a separate package.

Duplicate of #6 but without an accidentally pushed binary.
